### PR TITLE
Change RPC types per CKB change

### DIFF
--- a/Source/API/APIClient.swift
+++ b/Source/API/APIClient.swift
@@ -11,8 +11,9 @@ import Foundation
 /// JSON RPC API client.
 public class APIClient {
     private var url: URL
+    public static let defaultLocalURL = URL(string: "http://localhost:8114")!
 
-    public init(url: URL = URL(string: "http://localhost:8114")!) {
+    public init(url: URL = APIClient.defaultLocalURL) {
         self.url = url
     }
 
@@ -62,7 +63,7 @@ public class APIClient {
 
 extension APIClient {
     public func genesisBlockHash() throws -> H256 {
-        return try getBlockHash(number: 0)
+        return try getBlockHash(number: "0")
     }
 
     public func genesisBlock() throws -> Block {

--- a/Source/Types/Header.swift
+++ b/Source/Types/Header.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 public struct Seal: Codable {
-    public let nonce: UInt64
+    public let nonce: String
     public let proof: HexString
 }
 
 public struct Header: Codable {
     public let version: UInt32
     public let parentHash: H256
-    public let timestamp: UInt64
+    public let timestamp: String
     public let number: BlockNumber
     public let txsCommit: H256
     public let txsProposal: H256

--- a/Source/Types/Primitives.swift
+++ b/Source/Types/Primitives.swift
@@ -13,8 +13,8 @@ public typealias H256 = String // No strict typing for now.
 public typealias UInt256 = String // e.g. 0x400, TODO: Define a custom type?
 public typealias HexString = String // Present hex format data
 public typealias ProposalShortId = [UInt8] // Fixed 10-element array representing short hash.
-public typealias Capacity = UInt64
-public typealias BlockNumber = UInt64
+public typealias Capacity = String
+public typealias BlockNumber = String
 
 extension H256 {
     public static let zeroHash: H256 = "0000000000000000000000000000000000000000000000000000000000000000"

--- a/Source/Types/Script.swift
+++ b/Source/Types/Script.swift
@@ -9,18 +9,17 @@
 import Foundation
 
 public struct Script: Codable, Param {
-    public let version: UInt8
     public let args: [HexString]
     public var binaryHash: H256
 
     enum CodingKeys: String, CodingKey {
-        case version, args
+        case args
         case binaryHash = "binary_hash"
     }
 
     static let alwaysSuccessHash: H256 = "0000000000000000000000000000000000000000000000000000000000000001"
     public static var alwaysSuccess: Script {
-        return Script(version: 0, args: [], binaryHash: alwaysSuccessHash)
+        return Script(args: [], binaryHash: alwaysSuccessHash)
     }
 
     public var typeHash: String {
@@ -35,14 +34,12 @@ public struct Script: Codable, Param {
 
     public var param: [String: Any] {
         return [
-            CodingKeys.version.rawValue: version,
             CodingKeys.args.rawValue: args,
             CodingKeys.binaryHash.rawValue: binaryHash
         ]
     }
 
-    public init(version: UInt8 = 0, args: [HexString] = [], binaryHash: H256 = H256.zeroHash) {
-        self.version = version
+    public init(args: [HexString] = [], binaryHash: H256 = H256.zeroHash) {
         self.args = args
         self.binaryHash = binaryHash
     }
@@ -55,7 +52,6 @@ public extension Script {
             // Although public key itself is a hex string, when loaded as binary the format is ignored.
         ]
         return Script(
-            version: 0,
             args: args,
             binaryHash: binaryHash
         )

--- a/Tests/API/APIClientTests.swift
+++ b/Tests/API/APIClientTests.swift
@@ -17,101 +17,108 @@ class APIClientTests: XCTestCase {
         super.invokeTest()
     }
 
-    func testGenesisBlockHash() throws {
-        let result = try APIClient().genesisBlockHash()
+    func testGenesisBlockHash() {
+        let result = try? client.genesisBlockHash()
         XCTAssertNotNil(result)
     }
 
     func testGenesisBlock() throws {
-        let result = try APIClient().genesisBlock()
+        let result = try client.genesisBlock()
         XCTAssertNotNil(result)
     }
 
     func testGetBlock() throws {
-        let client = APIClient()
         let hash = try client.genesisBlockHash()
         let result = try client.getBlock(hash: hash)
         XCTAssertNotNil(result)
         XCTAssertEqual(hash, result.header.hash)
+
+        XCTAssertNil(try? client.getBlock(hash: nonexistentHash))
     }
 
     func testGetBlockPerformance() throws {
-        let client = APIClient()
         measure {
             _ = try! client.genesisBlock()
         }
     }
 
     func testGetTransaction() throws {
-        let client = APIClient()
         let genesisBlock = try client.genesisBlock()
         if let tx = genesisBlock.commitTransactions.first {
             let result = try client.getTransaction(hash: tx.hash)
             XCTAssertNotNil(result)
             XCTAssertEqual(tx.hash, result.hash)
         }
+
+        XCTAssertNil(try? client.getTransaction(hash: nonexistentHash))
     }
 
     func testGetBlockHash() throws {
-        let result = try APIClient().getBlockHash(number: 1)
+        let result = try client.getBlockHash(number: "1")
         XCTAssertNotNil(result)
     }
 
     func testGetTipHeader() throws {
-        let client = APIClient()
         let result = try client.getTipHeader()
         XCTAssertNotNil(result)
-        XCTAssertTrue(result.number > 0)
+        XCTAssertTrue(Int64(result.number)! > 0)
     }
 
     func testGetCellsByLockHash() throws {
-        let client = APIClient()
-        let result = try client.getCellsByLockHash(lockHash: "0x321c1ca2887fb8eddaaa7e917399f71e63e03a1c83ff75ed12099a01115ea2ff", from: 1, to: 100)
+        let result = try client.getCellsByLockHash(lockHash: "0x321c1ca2887fb8eddaaa7e917399f71e63e03a1c83ff75ed12099a01115ea2ff", from: "1", to: "100")
         XCTAssertNotNil(result)
+
+        XCTAssertTrue(try client.getCellsByLockHash(lockHash: nonexistentHash, from: "1", to: "100").isEmpty)
     }
 
     func testGetLiveCell() throws {
-        let client = APIClient()
-        let cells = try client.getCellsByLockHash(lockHash: "0x321c1ca2887fb8eddaaa7e917399f71e63e03a1c83ff75ed12099a01115ea2ff", from: 1, to: 100)
+        let cells = try client.getCellsByLockHash(lockHash: "0x321c1ca2887fb8eddaaa7e917399f71e63e03a1c83ff75ed12099a01115ea2ff", from: "1", to: "100")
         if let cell = cells.first {
             let result = try client.getLiveCell(outPoint: cell.outPoint)
             XCTAssertNotNil(result)
         }
+
+        XCTAssertTrue(try client.getCellsByLockHash(lockHash: nonexistentHash, from: "1", to: "100").isEmpty)
     }
 
     func testGetTipBlockNumber() throws {
-        let client = APIClient()
         let result = try client.getTipBlockNumber()
-        XCTAssertTrue(result > 0)
+        XCTAssertTrue(Int64(result)! > 0)
     }
 
-    func x_testSendTransaction() throws {
+    func testSendTransactionEmpty() throws {
         let tx = Transaction()
-        let client = APIClient()
-        let result = try client.sendTransaction(transaction: tx)
-        XCTAssertNotNil(result)
+        let result = try? client.sendTransaction(transaction: tx)
+        XCTAssertNil(result)
     }
 
     func testLocalNodeInfo() throws {
-        let client = APIClient()
         let result = try client.localNodeInfo()
         XCTAssertFalse(result.addresses.isEmpty)
         XCTAssertFalse(result.nodeId.isEmpty)
     }
 
-    func testGetTransactionTrace() throws {
-        let client = APIClient()
-        do {
-            let _ = try client.getTransactionTrace(hash: "0x1704f772f11c4c2fcb543f22cad66adad5a555e21f14c975c37d1d4bad096d47")
-        } catch {
-            XCTAssert(true, "Should throw APIError.emptyResponse")
-        }
+    func testGetTransactionTraceNioneExistence() throws {
+        XCTAssertNil(try? client.getTransactionTrace(hash: nonexistentHash))
     }
 
-    func x_testTraceTransaction() throws {
-        let client = APIClient()
-        let tx = Transaction(version: 0, deps: [], inputs: [], outputs: [])
-        let result = try client.traceTransaction(transaction: tx)
-        XCTAssertFalse(result.isEmpty)
+    func testTraceTransactionEmpty() throws {
+        let tx = Transaction(deps: [], inputs: [], outputs: [], witnesses: [])
+        let result = try? client.traceTransaction(transaction: tx)
+        XCTAssertNil(result)
+    }
+}
+
+private extension APIClientTests {
+    var node: URL {
+        return APIClient.defaultLocalURL
+    }
+
+    var client: APIClient {
+        return APIClient(url: node)
+    }
+
+    var nonexistentHash: H256 {
+        return "0x00000000000000000000000067d82224e6619896c7f12bb73a14dd9329af9c8d"
     }
 }

--- a/Tests/Types/ScriptTests.swift
+++ b/Tests/Types/ScriptTests.swift
@@ -17,7 +17,6 @@ class ScriptTests: XCTestCase {
 
     func testScriptTypeHash() throws {
         let script = Script(
-            version: 0,
             args: ["0x01"],
             binaryHash: H256.zeroHash
         )


### PR DESCRIPTION
* Remove several version field
* Change field type UInt64 to String

BREAKING CHANGE: RPC types and fields are changed and client needs to update to adapt.