### PR TITLE
chore(ci): Configure travis to install ckb binary and run rpc tests o…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,31 @@
 language: swift
 osx_image: xcode10.2
-env:
-  - SKIP_RPC_TESTS=1
 
 xcode_workspace: CKB.xcworkspace
 xcode_scheme: CKB
 xcode_destination: platform=OS X,arch=x86_64
+
 before_install:
   - gem install cocoapods -N
   - pod --version
   - travis_wait pod repo update --silent
+
+matrix:
+  include:
+    - name: Tests without RPC
+      if: NOT branch = master
+      env: SKIP_RPC_TESTS=1
+    - name: Tests with RPC
+      if: branch = master
+      env: SKIP_RPC_TESTS=0
+      before_script:
+        - mkdir ckb
+        - curl -O -L https://github.com/nervosnetwork/ckb/releases/download/v0.13.0/ckb_v0.13.0_x86_64-apple-darwin.zip
+        - unzip ckb_v0.13.0_x86_64-apple-darwin.zip
+        - export PATH=$PATH:$PWD/ckb_v0.13.0_x86_64-apple-darwin/
+        - ckb init
+        - ckb run&
+
+
 after_success:
   - bash <(curl -s https://codecov.io/bash) -J 'CKB'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Platform](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20Linux-4e4e4e.svg?colorA=28a745)](#installation)
 [![TravisCI](https://travis-ci.com/nervosnetwork/ckb-sdk-swift.svg?branch=develop)](https://travis-ci.com/nervosnetwork/ckb-sdk-swift)
-[![Codecov](https://codecov.io/gh/nervosnetwork/ckb-sdk-swift/branch/develop/graph/badge.svg)](https://codecov.io/gh/nervosnetwork/ckb-sdk-swift/branch/develop)
+[![Codecov](https://codecov.io/gh/nervosnetwork/ckb-sdk-swift/branch/master/graph/badge.svg)](https://codecov.io/gh/nervosnetwork/ckb-sdk-swift/branch/master)
 [![Telegram Group](https://cdn.rawgit.com/Patrolavia/telegram-badge/8fe3382b/chat.svg)](https://t.me/nervos_ckb_dev)
 
 Swift SDK for Nervos [CKB](https://github.com/nervosnetwork/ckb).


### PR DESCRIPTION
…n master branch

When running based on `master`, download and start CKB binary, and enable RPC tests.
Otherwise skip the above.

The side effect is `master` would have a higher coverage while other branches won't. So we show the master branch codecov badge.

One draw back is when we release RC to master we need to wait for CKB's release first - then it'll be able to run against that new version of CKB binary.