### PR TITLE
[ᚬmaster] Rc/v0.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       name: Tests with RPC
       env:
         - SKIP_RPC_TESTS=0
-        - CKB_VERSION=v0.15.6
+        - CKB_VERSION=v0.16.0
         - CKB_FILENAME=ckb_${CKB_VERSION}_x86_64-apple-darwin
       before_script:
         - mkdir ckb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [v0.16.0](https://github.com/nervosnetwork/ckb-sdk-swift/compare/v0.15.0...v0.16.0) (2019-07-13)
+
+
+* Update to support CKB v0.16.0.
+
+
 # [v0.15.0](https://github.com/nervosnetwork/ckb-sdk-swift/compare/v0.14.0...v0.15.0) (2019-06-29)
 
 

--- a/CKB.podspec
+++ b/CKB.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CKB"
-  s.version      = "0.15.0"
+  s.version      = "0.16.0"
   s.summary      = "Swift SDK for Nervos CKB"
 
   s.description  = <<-DESC

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.15.0</string>
+	<string>0.16.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
       sdk: 'macosx10.14'
       configuration: 'Debug'
       skip_rpc_tests: 0
-      ckb_version: 'v0.15.6'
+      ckb_version: 'v0.16.0'
     steps:
       - task: CocoaPods@0
         displayName: 'pod install using the CocoaPods task with defaults'


### PR DESCRIPTION
# [v0.16.0](https://github.com/nervosnetwork/ckb-sdk-swift/compare/v0.15.0...v0.16.0) (2019-07-13)


* Update to support CKB v0.16.0.

## TODO
 - [x] Update CKB binary for CI