### PR TITLE
feat: Update address generator as per recent RFC 21 change

### DIFF
--- a/Source/Utils/AddressGenerator.swift
+++ b/Source/Utils/AddressGenerator.swift
@@ -8,8 +8,9 @@
 
 import Foundation
 
-/// Address generator based on CKB Address Format [RFC](https://github.com/nervosnetwork/rfcs/blob/4f87099a0b1a02a8bc077fc7bea15ce3d9def120/rfcs/0000-address-format/0000-address-format.md),
+/// Address generator based on CKB Address Format [RFC](https://github.com/nervosnetwork/rfcs/blob/c6b74309e071fd631c12c5f7152a265d7db833f6/rfcs/0000-address-format/0000-address-format.md),
 /// and [Common Address Format](https://github.com/nervosnetwork/ckb/wiki/Common-Address-Format).
+/// Currently we implement the predefined format for type 0x01 and code hash index 0x00.
 public class AddressGenerator {
     let network: Network
 
@@ -46,10 +47,10 @@ public class AddressGenerator {
     }
 
     public func address(publicKeyHash: Data) -> String {
-        // Payload: type(01) | bin-idx("P2PH") | pubkey blake160
+        // Payload: type(01) | code hash index(00, P2PH) | pubkey blake160
         let type = Data([0x01])
-        let binIdx = "P2PH".data(using: .ascii)!
-        let payload = type + binIdx + publicKeyHash
+        let codeHashIndex = Data([0x00])
+        let payload = type + codeHashIndex + publicKeyHash
         return Bech32().encode(hrp: prefix, data: convertBits(data: payload, fromBits: 8, toBits: 5, pad: true)!)
     }
 

--- a/Tests/Utils/AddressGeneratorTests.swift
+++ b/Tests/Utils/AddressGeneratorTests.swift
@@ -19,15 +19,15 @@ class AddressGeneratorTests: XCTestCase {
     func testPubkeyToAddressTestnet() {
         let generator = AddressGenerator(network: .testnet)
         XCTAssertEqual(
-            "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf",
+            "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83",
             generator.address(for: "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01")
         )
         XCTAssertEqual(
-            "ckt1q9gry5zgqt5rp0t0uxv39lahkzcnfjl9x9utn683yv9zxs",
+            "ckt1qyqq96psh4h7rxgjl7mmpvf5e0jnz79earcsyrlxrx",
             generator.address(for: "0x0331b3c0225388c5010e3507beb28ecf409c022ef6f358f02b139cbae082f5a2a3")
         )
         XCTAssertEqual(
-            "ckt1q9gry5zg7r0qgqc3vnvy8pwr0q8mkgvgywfjazg9xlz2ev",
+            "ckt1qyq0phsyqvgkfkzrshphsramyxyz8yew3yzsl76naf",
             generator.address(for: "0x0360bf05c11e7b4ac8de58077554e3d777acd64bf4abb9cd947002eb98a4827bba")
         )
     }
@@ -35,7 +35,7 @@ class AddressGeneratorTests: XCTestCase {
     func testPubkeyToAddressMainnet() {
         let generator = AddressGenerator(network: .mainnet)
         XCTAssertEqual(
-            "ckb1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6vqdd7em",
+            "ckb1qyqrdsefa43s6m882pcj53m4gdnj4k440axqdt9rtd",
             generator.address(for: "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01")
         )
     }
@@ -43,11 +43,11 @@ class AddressGeneratorTests: XCTestCase {
     func testPubkeyHashToAddressTestnet() {
         let generator = AddressGenerator(network: .testnet)
         XCTAssertEqual(
-            "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf",
+            "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83",
             generator.address(publicKeyHash: "0x36c329ed630d6ce750712a477543672adab57f4c")
         )
         XCTAssertEqual(
-            "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf",
+            "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83",
             generator.address(publicKeyHash: Data(hex: "0x36c329ed630d6ce750712a477543672adab57f4c"))
         )
     }
@@ -55,12 +55,24 @@ class AddressGeneratorTests: XCTestCase {
     func testPubkeyHashToAddressMainnet() {
         let generator = AddressGenerator(network: .mainnet)
         XCTAssertEqual(
-            "ckb1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6vqdd7em",
+            "ckb1qyqrdsefa43s6m882pcj53m4gdnj4k440axqdt9rtd",
             generator.address(publicKeyHash: "0x36c329ed630d6ce750712a477543672adab57f4c")
         )
         XCTAssertEqual(
-            "ckb1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6vqdd7em",
+            "ckb1qyqrdsefa43s6m882pcj53m4gdnj4k440axqdt9rtd",
             generator.address(publicKeyHash: Data(hex: "0x36c329ed630d6ce750712a477543672adab57f4c"))
+        )
+    }
+
+    func testPubkeyHashToAddressMainnetRFC() {
+        let generator = AddressGenerator(network: .mainnet)
+        XCTAssertEqual(
+            "ckb1qyqp8eqad7ffy42ezmchkjyz54rhcqf8q9pqrn323p",
+            generator.address(publicKeyHash: "0x13e41d6F9292555916f17B4882a5477C01270142")
+        )
+        XCTAssertEqual(
+            "ckb1qyqp8eqad7ffy42ezmchkjyz54rhcqf8q9pqrn323p",
+            generator.address(publicKeyHash: Data(hex: "0x13e41d6F9292555916f17B4882a5477C01270142"))
         )
     }
 

--- a/Tests/Utils/UtilsTests.swift
+++ b/Tests/Utils/UtilsTests.swift
@@ -18,19 +18,19 @@ class UtilsTests: XCTestCase {
 
     func testPrivateToAddress() {
         let privateKey = "e79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3"
-        let address = "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf"
+        let address = "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83"
         XCTAssertEqual(address, Utils.privateToAddress(privateKey))
     }
 
     func testPublicToAddress() {
         let publicKey = "024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01"
-        let address = "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf"
+        let address = "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83"
         XCTAssertEqual(address, Utils.publicToAddress(publicKey))
     }
 
     func testPublicKeyHashToAddress() {
         let publicKeyHash = "0x36c329ed630d6ce750712a477543672adab57f4c"
-        let address = "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf"
+        let address = "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83"
         XCTAssertEqual(address, Utils.publicKeyHashToAddress(publicKeyHash))
     }
 


### PR DESCRIPTION
BREAKING CHANGE: A public key will derive different address from previous implementation.
As the code hash index has been changed from 4 bytes to 1 byte, the first serveral fixed
characters will become ckt1qyq from ckb1q9gry5zg and be shorter.

https://github.com/nervosnetwork/rfcs/pull/100