### PR TITLE
Util for calculating lock script for pub key (or hash)

### DIFF
--- a/Examples/Example-iOS/Example-iOS/ViewController.swift
+++ b/Examples/Example-iOS/Example-iOS/ViewController.swift
@@ -96,13 +96,13 @@ private extension ViewController {
 
         // Generate lock script for the receiver's address
         let toAddress = "ckt..."
-        let addressHash = Utils.prefixHex(AddressGenerator(network: .testnet).publicKeyHash(for: toAddress)!)
-        let lockScript = Script(args: [addressHash], codeHash: systemScript.secp256k1TypeHash, hashType: .type)
+        let publicKeyHash = Utils.prefixHex(AddressGenerator(network: .testnet).publicKeyHash(for: toAddress)!)
+        let lockScript = systemScript.lock(for: publicKeyHash)
         // Construct the outputs
         let outputs = [CellOutput(capacity: 500_00_000_000.description, lock: lockScript, type: nil)]
 
         // Generate the transaction
-        let tx = Transaction(cellDeps: deps, inputs: inputs, outputs: outputs, witnesses: [Witness(data: [])])
+        let tx = Transaction(cellDeps: deps, inputs: inputs, outputs: outputs, outputsData: ["0x"], witnesses: [Witness(data: [])])
         // For now we need to call the `computeTransactionHash` to get the tx hash
         let apiClient = APIClient(url: nodeUrl)
         let txHash = try apiClient.computeTransactionHash(transaction: tx)
@@ -110,6 +110,6 @@ private extension ViewController {
 
         // Now send out the capacity
         let hash = try apiClient.sendTransaction(transaction: signedTx)
-        print(hash) // hash should equal to txHash
+        print(hash) // hash should be equal to txHash
     }
 }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ print(height)                                  // "10420"
 ### Send Capacity Example
 
 ```swift
+// Fetch system script which we'll use to generate lock for address
 let systemScript = try SystemScript.loadSystemScript(nodeUrl: nodeUrl)
 // Fill in the sender's private key
 let privateKey: Data = Data(hex: "your private key (hex string)")
@@ -80,13 +81,13 @@ let inputs: [CellInput] = [/*...*/]
 
 // Generate lock script for the receiver's address
 let toAddress = "ckt..."
-let addressHash = Utils.prefixHex(AddressGenerator(network: .testnet).publicKeyHash(for: toAddress)!)
-let lockScript = Script(args: [addressHash], codeHash: systemScript.secp256k1TypeHash, hashType: .type)
+let publicKeyHash = Utils.prefixHex(AddressGenerator(network: .testnet).publicKeyHash(for: toAddress)!)
+let lockScript = systemScript.lock(for: publicKeyHash)
 // Construct the outputs
 let outputs = [CellOutput(capacity: 500_00_000_000.description, lock: lockScript, type: nil)]
 
 // Generate the transaction
-let tx = Transaction(cellDeps: deps, inputs: inputs, outputs: outputs, witnesses: [Witness(data: [])])
+let tx = Transaction(cellDeps: deps, inputs: inputs, outputs: outputs, outputsData: ["0x"], witnesses: [Witness(data: [])])
 // For now we need to call the `computeTransactionHash` to get the tx hash
 let apiClient = APIClient(url: nodeUrl)
 let txHash = try apiClient.computeTransactionHash(transaction: tx)
@@ -94,7 +95,7 @@ let signedTx = try Transaction.sign(tx: tx, with: privateKey, txHash: txHash)
 
 // Now send out the capacity
 let hash = try apiClient.sendTransaction(transaction: signedTx)
-print(hash) // hash should equal to txHash
+print(hash) // hash should be equal to txHash
 ```
 
 ## Getting Help

--- a/Source/Utils/SystemScript.swift
+++ b/Source/Utils/SystemScript.swift
@@ -34,4 +34,9 @@ public struct SystemScript {
 
         return SystemScript(depOutPoint: depOutPoint, secp256k1TypeHash: secp256k1TypeHash)
     }
+
+    public func lock(for publicKey: String) -> Script {
+        let pubkeyHash = Utils.prefixHex(AddressGenerator().hash(for: Data(hex: publicKey)).toHexString())
+        return Script(args: [pubkeyHash], codeHash: secp256k1TypeHash, hashType: .type)
+    }
 }

--- a/Source/Utils/SystemScript.swift
+++ b/Source/Utils/SystemScript.swift
@@ -35,8 +35,12 @@ public struct SystemScript {
         return SystemScript(depOutPoint: depOutPoint, secp256k1TypeHash: secp256k1TypeHash)
     }
 
-    public func lock(for publicKey: String) -> Script {
-        let pubkeyHash = Utils.prefixHex(AddressGenerator().hash(for: Data(hex: publicKey)).toHexString())
-        return Script(args: [pubkeyHash], codeHash: secp256k1TypeHash, hashType: .type)
+    public func lock(for publicKey: Data) -> Script {
+        let publicKeyHash = Utils.prefixHex(AddressGenerator().hash(for: publicKey).toHexString())
+        return lock(for: publicKeyHash)
+    }
+
+    public func lock(for publicKeyHash: String) -> Script {
+        return Script(args: [publicKeyHash], codeHash: secp256k1TypeHash, hashType: .type)
     }
 }

--- a/Tests/Utils/SystemScriptTests.swift
+++ b/Tests/Utils/SystemScriptTests.swift
@@ -13,4 +13,12 @@ class SystemScriptTests: RPCTestSkippable {
         XCTAssertNotNil(systemScript)
         XCTAssertEqual("0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88", systemScript.secp256k1TypeHash)
     }
+
+    func x_testPublicKeyToScript() throws {
+        let privateKey = Data(hex: "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3")
+        let publicKey = Utils.privateToPublic(privateKey)
+        let systemScript = try SystemScript.loadSystemScript(nodeUrl: APIClient.defaultLocalURL)
+        let lockScript = systemScript.lock(for: publicKey.toHexString())
+        XCTAssertEqual("0x024b0fd0c4912e98aab6808f6474cacb1969255d526b3cac5d3bdd15962a8818", lockScript.hash)
+    }
 }

--- a/Tests/Utils/SystemScriptTests.swift
+++ b/Tests/Utils/SystemScriptTests.swift
@@ -18,7 +18,14 @@ class SystemScriptTests: RPCTestSkippable {
         let privateKey = Data(hex: "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3")
         let publicKey = Utils.privateToPublic(privateKey)
         let systemScript = try SystemScript.loadSystemScript(nodeUrl: APIClient.defaultLocalURL)
-        let lockScript = systemScript.lock(for: publicKey.toHexString())
+        let lockScript = systemScript.lock(for: publicKey)
+        XCTAssertEqual("0x024b0fd0c4912e98aab6808f6474cacb1969255d526b3cac5d3bdd15962a8818", lockScript.hash)
+    }
+
+    func x_testPublicKeyHashToScript() throws {
+        let systemScript = try SystemScript.loadSystemScript(nodeUrl: APIClient.defaultLocalURL)
+        let publicKeyHash = "0x36c329ed630d6ce750712a477543672adab57f4c"
+        let lockScript = systemScript.lock(for: publicKeyHash)
         XCTAssertEqual("0x024b0fd0c4912e98aab6808f6474cacb1969255d526b3cac5d3bdd15962a8818", lockScript.hash)
     }
 }

--- a/Tests/Utils/SystemScriptTests.swift
+++ b/Tests/Utils/SystemScriptTests.swift
@@ -14,18 +14,22 @@ class SystemScriptTests: RPCTestSkippable {
         XCTAssertEqual("0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88", systemScript.secp256k1TypeHash)
     }
 
-    func x_testPublicKeyToScript() throws {
+    func testPublicKeyToScript() throws {
         let privateKey = Data(hex: "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3")
         let publicKey = Utils.privateToPublic(privateKey)
         let systemScript = try SystemScript.loadSystemScript(nodeUrl: APIClient.defaultLocalURL)
         let lockScript = systemScript.lock(for: publicKey)
-        XCTAssertEqual("0x024b0fd0c4912e98aab6808f6474cacb1969255d526b3cac5d3bdd15962a8818", lockScript.hash)
+        let lockHash = try APIClient(url: APIClient.defaultLocalURL).computeScriptHash(script: lockScript)
+        // let lockHash = lockScript.hash // TODO: Switch to this after serialization implemented
+        XCTAssertEqual("0x024b0fd0c4912e98aab6808f6474cacb1969255d526b3cac5d3bdd15962a8818", lockHash)
     }
 
-    func x_testPublicKeyHashToScript() throws {
+    func testPublicKeyHashToScript() throws {
         let systemScript = try SystemScript.loadSystemScript(nodeUrl: APIClient.defaultLocalURL)
         let publicKeyHash = "0x36c329ed630d6ce750712a477543672adab57f4c"
         let lockScript = systemScript.lock(for: publicKeyHash)
-        XCTAssertEqual("0x024b0fd0c4912e98aab6808f6474cacb1969255d526b3cac5d3bdd15962a8818", lockScript.hash)
+        let lockHash = try APIClient(url: APIClient.defaultLocalURL).computeScriptHash(script: lockScript)
+        // let lockHash = lockScript.hash // TODO: Switch to this after serialization implemented
+        XCTAssertEqual("0x024b0fd0c4912e98aab6808f6474cacb1969255d526b3cac5d3bdd15962a8818", lockHash)
     }
 }


### PR DESCRIPTION
It attaches to `SystemScript` as it the default secp256k1 lock script relies on genesis block and system script.