### PR TITLE
[ᚬmaster] Rc/v0.20.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       name: Tests with RPC
       env:
         - SKIP_RPC_TESTS=0
-        - CKB_VERSION=v0.20.0-rc1
+        - CKB_VERSION=v0.20.0
         - CKB_FILENAME=ckb_${CKB_VERSION}_x86_64-apple-darwin
       before_script:
         - mkdir ckb

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       name: Tests with RPC
       env:
         - SKIP_RPC_TESTS=0
-        - CKB_VERSION=v0.20.0-pre1
+        - CKB_VERSION=v0.20.0-rc1
         - CKB_FILENAME=ckb_${CKB_VERSION}_x86_64-apple-darwin
       before_script:
         - mkdir ckb

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       name: Tests with RPC
       env:
         - SKIP_RPC_TESTS=0
-        - CKB_VERSION=v0.19.2
+        - CKB_VERSION=v0.20.0-pre1
         - CKB_FILENAME=ckb_${CKB_VERSION}_x86_64-apple-darwin
       before_script:
         - mkdir ckb

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       name: Tests with RPC
       env:
         - SKIP_RPC_TESTS=0
-        - CKB_VERSION=v0.19.1
+        - CKB_VERSION=v0.19.2
         - CKB_FILENAME=ckb_${CKB_VERSION}_x86_64-apple-darwin
       before_script:
         - mkdir ckb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 * Add public key hash to lock script util ([c4096d2](https://github.com/nervosnetwork/ckb-sdk-swift/commit/c4096d2))
 * Add public key to lock script util ([8dd1844](https://github.com/nervosnetwork/ckb-sdk-swift/commit/8dd1844))
+* Extract and make public of TransactionSerializer/ScriptSerializer ([8c79f70](https://github.com/nervosnetwork/ckb-sdk-swift/commit/8c79f70))
+* Implement Array Serializer(s) ([b8598fd](https://github.com/nervosnetwork/ckb-sdk-swift/commit/b8598fd))
+* Implement ByteSerializer ([eb64ddd](https://github.com/nervosnetwork/ckb-sdk-swift/commit/eb64ddd))
+* Implement DynVecSerializer ([a87a8da](https://github.com/nervosnetwork/ckb-sdk-swift/commit/a87a8da))
+* Implement FixVecSerializer, refactor other serializers ([16b6186](https://github.com/nervosnetwork/ckb-sdk-swift/commit/16b6186))
+* Implement StructSerializer ([6530566](https://github.com/nervosnetwork/ckb-sdk-swift/commit/6530566))
+* Implement TableSerializer ([fad544e](https://github.com/nervosnetwork/ckb-sdk-swift/commit/fad544e))
+* Implement transaction serialization and other type serializers ([ea0eeeb](https://github.com/nervosnetwork/ckb-sdk-swift/commit/ea0eeeb))
+* Re-implement ByteSerializer ([9fecdd1](https://github.com/nervosnetwork/ckb-sdk-swift/commit/9fecdd1))
+* Update Script to use Molecule serialization ([013c4b3](https://github.com/nervosnetwork/ckb-sdk-swift/commit/013c4b3))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [v0.20.0](https://github.com/nervosnetwork/ckb-sdk-swift/compare/v0.19.0...v0.20.0) (2019-09-07)
+
+
+### Features
+
+* Add public key hash to lock script util ([c4096d2](https://github.com/nervosnetwork/ckb-sdk-swift/commit/c4096d2))
+* Add public key to lock script util ([8dd1844](https://github.com/nervosnetwork/ckb-sdk-swift/commit/8dd1844))
+
+
+
 # [v0.19.0](https://github.com/nervosnetwork/ckb-sdk-swift/compare/v0.18.0...v0.19.0) (2019-08-27)
 
 

--- a/CKB.podspec
+++ b/CKB.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CKB"
-  s.version      = "0.19.0"
+  s.version      = "0.20.0"
   s.summary      = "Swift SDK for Nervos CKB"
 
   s.description  = <<-DESC

--- a/CKB.xcodeproj/project.pbxproj
+++ b/CKB.xcodeproj/project.pbxproj
@@ -45,6 +45,15 @@
 		1A2D6B3B22A35C6400724E66 /* pubkey.json in Resources */ = {isa = PBXBuildFile; fileRef = 1A5BCBAF228C53C000157426 /* pubkey.json */; };
 		1A2D6B3C22A35C6400724E66 /* Secp256k1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB45ED9222AA644009B395B /* Secp256k1Tests.swift */; };
 		1A2D6B3D22A35C6400724E66 /* Blake2bTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1C826B222F5D7B0053EC32 /* Blake2bTests.swift */; };
+		1A2F5FB72321F1FE000051CC /* SerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2F5FB62321F1FE000051CC /* SerializerTests.swift */; };
+		1A2F5FB923223D9F000051CC /* ScriptSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2F5FB823223D9F000051CC /* ScriptSerializer.swift */; };
+		1A2F5FBB23223DF1000051CC /* TransactionSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2F5FBA23223DF1000051CC /* TransactionSerializer.swift */; };
+		1A36096B2322853F000E67EE /* CellOutputSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A36096A2322853F000E67EE /* CellOutputSerializer.swift */; };
+		1A36096D23228675000E67EE /* CellDepSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A36096C23228675000E67EE /* CellDepSerializer.swift */; };
+		1A36096F23228979000E67EE /* CellInputSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A36096E23228979000E67EE /* CellInputSerializer.swift */; };
+		1A36097123228ADF000E67EE /* OutPointSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A36097023228ADF000E67EE /* OutPointSerializer.swift */; };
+		1A36097423228B22000E67EE /* ScriptSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A36097323228B22000E67EE /* ScriptSerializerTests.swift */; };
+		1A36097623228B6C000E67EE /* TransactionSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A36097523228B6C000E67EE /* TransactionSerializerTests.swift */; };
 		1A38CA6422768E7900BEA1F3 /* APIMockingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A38CA6322768E7900BEA1F3 /* APIMockingClient.swift */; };
 		1A414A7121C2226E00B28C09 /* CKB.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A414A6321C2226E00B28C09 /* CKB.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1A414A7B21C22A9300B28C09 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A414A7A21C22A9300B28C09 /* APIClient.swift */; };
@@ -73,6 +82,23 @@
 		1A54E26222EEA9E1008CF6C3 /* getBannedAddresses.json in Resources */ = {isa = PBXBuildFile; fileRef = 1A55D39E22EEA7F300E2B8DE /* getBannedAddresses.json */; };
 		1A54E26822EEB5BA008CF6C3 /* blockReward.json in Resources */ = {isa = PBXBuildFile; fileRef = 1A54E26722EEB5BA008CF6C3 /* blockReward.json */; };
 		1A5BCBB3228C571200157426 /* Transaction+Sign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5BCBB2228C571200157426 /* Transaction+Sign.swift */; };
+		1A703C29231FAEF800EDF2C6 /* DynVecSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C28231FAEF800EDF2C6 /* DynVecSerializer.swift */; };
+		1A703C2B231FAF1000EDF2C6 /* FixVecSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C2A231FAF1000EDF2C6 /* FixVecSerializer.swift */; };
+		1A703C2D231FAF2400EDF2C6 /* FixVecSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C2C231FAF2400EDF2C6 /* FixVecSerializerTests.swift */; };
+		1A703C2F231FAF3600EDF2C6 /* DynVecSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C2E231FAF3600EDF2C6 /* DynVecSerializerTests.swift */; };
+		1A703C31231FAF5900EDF2C6 /* TableSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C30231FAF5900EDF2C6 /* TableSerializer.swift */; };
+		1A703C33231FAF6300EDF2C6 /* TableSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C32231FAF6300EDF2C6 /* TableSerializerTests.swift */; };
+		1A703C35231FAF8600EDF2C6 /* StructSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C34231FAF8600EDF2C6 /* StructSerializer.swift */; };
+		1A703C37231FAF9900EDF2C6 /* StructSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C36231FAF9900EDF2C6 /* StructSerializerTests.swift */; };
+		1A703C39231FB13800EDF2C6 /* ArraySerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C38231FB13800EDF2C6 /* ArraySerializer.swift */; };
+		1A703C3B231FB14800EDF2C6 /* ArraySerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C3A231FB14800EDF2C6 /* ArraySerializerTests.swift */; };
+		1A703C3D231FB16C00EDF2C6 /* OptionSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C3C231FB16C00EDF2C6 /* OptionSerializer.swift */; };
+		1A703C3F231FB17900EDF2C6 /* OptionSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C3E231FB17900EDF2C6 /* OptionSerializerTests.swift */; };
+		1A703C41231FB19A00EDF2C6 /* UnionSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C40231FB19A00EDF2C6 /* UnionSerializer.swift */; };
+		1A703C43231FB1AA00EDF2C6 /* UnionSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C42231FB1AA00EDF2C6 /* UnionSerializerTests.swift */; };
+		1A703C47232085CC00EDF2C6 /* Serializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A703C46232085CC00EDF2C6 /* Serializer.swift */; };
+		1A85454F23212A4100B26DC0 /* ByteSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A85454E23212A4100B26DC0 /* ByteSerializer.swift */; };
+		1A85455123212A5B00B26DC0 /* ByteSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A85455023212A5B00B26DC0 /* ByteSerializerTests.swift */; };
 		1AA3B83F22EEBAFA00027520 /* BannedAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA3B83D22EEBAFA00027520 /* BannedAddress.swift */; };
 		1AA3B84222EEBB4800027520 /* BlockReward.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA3B84122EEBB4800027520 /* BlockReward.swift */; };
 		1AA9B6842283CD4C00C116B2 /* ChainInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA9B6832283CD4C00C116B2 /* ChainInfo.swift */; };
@@ -123,6 +149,15 @@
 		1A2CDAE22281796D0024CA71 /* epoch.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = epoch.json; sourceTree = "<group>"; };
 		1A2D6B1722A35C3500724E66 /* CKBTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CKBTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A2D6B1B22A35C3500724E66 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1A2F5FB62321F1FE000051CC /* SerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializerTests.swift; sourceTree = "<group>"; };
+		1A2F5FB823223D9F000051CC /* ScriptSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptSerializer.swift; sourceTree = "<group>"; };
+		1A2F5FBA23223DF1000051CC /* TransactionSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSerializer.swift; sourceTree = "<group>"; };
+		1A36096A2322853F000E67EE /* CellOutputSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellOutputSerializer.swift; sourceTree = "<group>"; };
+		1A36096C23228675000E67EE /* CellDepSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellDepSerializer.swift; sourceTree = "<group>"; };
+		1A36096E23228979000E67EE /* CellInputSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellInputSerializer.swift; sourceTree = "<group>"; };
+		1A36097023228ADF000E67EE /* OutPointSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutPointSerializer.swift; sourceTree = "<group>"; };
+		1A36097323228B22000E67EE /* ScriptSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptSerializerTests.swift; sourceTree = "<group>"; };
+		1A36097523228B6C000E67EE /* TransactionSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSerializerTests.swift; sourceTree = "<group>"; };
 		1A38CA6322768E7900BEA1F3 /* APIMockingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIMockingClient.swift; sourceTree = "<group>"; };
 		1A414A6021C2226E00B28C09 /* CKB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CKB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A414A6321C2226E00B28C09 /* CKB.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CKB.h; sourceTree = "<group>"; };
@@ -170,6 +205,23 @@
 		1A5BCBAF228C53C000157426 /* pubkey.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = pubkey.json; sourceTree = "<group>"; };
 		1A5BCBB2228C571200157426 /* Transaction+Sign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Transaction+Sign.swift"; sourceTree = "<group>"; };
 		1A5BCBB5228C6BB400157426 /* TransactionSignTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSignTests.swift; sourceTree = "<group>"; };
+		1A703C28231FAEF800EDF2C6 /* DynVecSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynVecSerializer.swift; sourceTree = "<group>"; };
+		1A703C2A231FAF1000EDF2C6 /* FixVecSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixVecSerializer.swift; sourceTree = "<group>"; };
+		1A703C2C231FAF2400EDF2C6 /* FixVecSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixVecSerializerTests.swift; sourceTree = "<group>"; };
+		1A703C2E231FAF3600EDF2C6 /* DynVecSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynVecSerializerTests.swift; sourceTree = "<group>"; };
+		1A703C30231FAF5900EDF2C6 /* TableSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableSerializer.swift; sourceTree = "<group>"; };
+		1A703C32231FAF6300EDF2C6 /* TableSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableSerializerTests.swift; sourceTree = "<group>"; };
+		1A703C34231FAF8600EDF2C6 /* StructSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StructSerializer.swift; sourceTree = "<group>"; };
+		1A703C36231FAF9900EDF2C6 /* StructSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StructSerializerTests.swift; sourceTree = "<group>"; };
+		1A703C38231FB13800EDF2C6 /* ArraySerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArraySerializer.swift; sourceTree = "<group>"; };
+		1A703C3A231FB14800EDF2C6 /* ArraySerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArraySerializerTests.swift; sourceTree = "<group>"; };
+		1A703C3C231FB16C00EDF2C6 /* OptionSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionSerializer.swift; sourceTree = "<group>"; };
+		1A703C3E231FB17900EDF2C6 /* OptionSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionSerializerTests.swift; sourceTree = "<group>"; };
+		1A703C40231FB19A00EDF2C6 /* UnionSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionSerializer.swift; sourceTree = "<group>"; };
+		1A703C42231FB1AA00EDF2C6 /* UnionSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionSerializerTests.swift; sourceTree = "<group>"; };
+		1A703C46232085CC00EDF2C6 /* Serializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Serializer.swift; sourceTree = "<group>"; };
+		1A85454E23212A4100B26DC0 /* ByteSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByteSerializer.swift; sourceTree = "<group>"; };
+		1A85455023212A5B00B26DC0 /* ByteSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByteSerializerTests.swift; sourceTree = "<group>"; };
 		1AA3B83D22EEBAFA00027520 /* BannedAddress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannedAddress.swift; sourceTree = "<group>"; };
 		1AA3B84122EEBB4800027520 /* BlockReward.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockReward.swift; sourceTree = "<group>"; };
 		1AA9B6832283CD4C00C116B2 /* ChainInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainInfo.swift; sourceTree = "<group>"; };
@@ -243,6 +295,7 @@
 			isa = PBXGroup;
 			children = (
 				1AB45ED8222AA624009B395B /* Crypto */,
+				1A703C27231F4BAC00EDF2C6 /* Serialization */,
 				1A28119521D3804600E7CEC5 /* Types */,
 				1A414A7F21C32D2500B28C09 /* API */,
 				1A5BCBB4228C6B9200157426 /* Signers */,
@@ -251,6 +304,28 @@
 				1A2D6B1B22A35C3500724E66 /* Info.plist */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		1A360969232284FB000E67EE /* TypeSerializers */ = {
+			isa = PBXGroup;
+			children = (
+				1A36097023228ADF000E67EE /* OutPointSerializer.swift */,
+				1A36096E23228979000E67EE /* CellInputSerializer.swift */,
+				1A36096A2322853F000E67EE /* CellOutputSerializer.swift */,
+				1A36096C23228675000E67EE /* CellDepSerializer.swift */,
+				1A2F5FB823223D9F000051CC /* ScriptSerializer.swift */,
+				1A2F5FBA23223DF1000051CC /* TransactionSerializer.swift */,
+			);
+			path = TypeSerializers;
+			sourceTree = "<group>";
+		};
+		1A36097223228B0D000E67EE /* TypeSerializers */ = {
+			isa = PBXGroup;
+			children = (
+				1A36097323228B22000E67EE /* ScriptSerializerTests.swift */,
+				1A36097523228B6C000E67EE /* TransactionSerializerTests.swift */,
+			);
+			path = TypeSerializers;
 			sourceTree = "<group>";
 		};
 		1A38CA6522768FDD00BEA1F3 /* RPC Fixtures */ = {
@@ -308,6 +383,7 @@
 			isa = PBXGroup;
 			children = (
 				1AB45ED5222AA53F009B395B /* Crypto */,
+				1A703C26231F4B8F00EDF2C6 /* Serialization */,
 				1A414A8621C36FAA00B28C09 /* Types */,
 				1A414A7E21C32D1D00B28C09 /* API */,
 				1A5BCBB1228C56DC00157426 /* Signers */,
@@ -421,6 +497,56 @@
 				1A5BCBB5228C6BB400157426 /* TransactionSignTests.swift */,
 			);
 			path = Signers;
+			sourceTree = "<group>";
+		};
+		1A703C26231F4B8F00EDF2C6 /* Serialization */ = {
+			isa = PBXGroup;
+			children = (
+				1A703C44231FB1C000EDF2C6 /* BaseSerializers */,
+				1A360969232284FB000E67EE /* TypeSerializers */,
+				1A703C46232085CC00EDF2C6 /* Serializer.swift */,
+			);
+			path = Serialization;
+			sourceTree = "<group>";
+		};
+		1A703C27231F4BAC00EDF2C6 /* Serialization */ = {
+			isa = PBXGroup;
+			children = (
+				1A703C45231FB1DB00EDF2C6 /* BaseSerializers */,
+				1A36097223228B0D000E67EE /* TypeSerializers */,
+				1A2F5FB62321F1FE000051CC /* SerializerTests.swift */,
+			);
+			path = Serialization;
+			sourceTree = "<group>";
+		};
+		1A703C44231FB1C000EDF2C6 /* BaseSerializers */ = {
+			isa = PBXGroup;
+			children = (
+				1A85454E23212A4100B26DC0 /* ByteSerializer.swift */,
+				1A703C38231FB13800EDF2C6 /* ArraySerializer.swift */,
+				1A703C34231FAF8600EDF2C6 /* StructSerializer.swift */,
+				1A703C2A231FAF1000EDF2C6 /* FixVecSerializer.swift */,
+				1A703C28231FAEF800EDF2C6 /* DynVecSerializer.swift */,
+				1A703C30231FAF5900EDF2C6 /* TableSerializer.swift */,
+				1A703C3C231FB16C00EDF2C6 /* OptionSerializer.swift */,
+				1A703C40231FB19A00EDF2C6 /* UnionSerializer.swift */,
+			);
+			path = BaseSerializers;
+			sourceTree = "<group>";
+		};
+		1A703C45231FB1DB00EDF2C6 /* BaseSerializers */ = {
+			isa = PBXGroup;
+			children = (
+				1A85455023212A5B00B26DC0 /* ByteSerializerTests.swift */,
+				1A703C3A231FB14800EDF2C6 /* ArraySerializerTests.swift */,
+				1A703C36231FAF9900EDF2C6 /* StructSerializerTests.swift */,
+				1A703C2C231FAF2400EDF2C6 /* FixVecSerializerTests.swift */,
+				1A703C2E231FAF3600EDF2C6 /* DynVecSerializerTests.swift */,
+				1A703C32231FAF6300EDF2C6 /* TableSerializerTests.swift */,
+				1A703C3E231FB17900EDF2C6 /* OptionSerializerTests.swift */,
+				1A703C42231FB1AA00EDF2C6 /* UnionSerializerTests.swift */,
+			);
+			path = BaseSerializers;
 			sourceTree = "<group>";
 		};
 		1AB45ED5222AA53F009B395B /* Crypto */ = {
@@ -689,6 +815,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				1A2D6B2322A35C4B00724E66 /* TestHelper.swift in Sources */,
+				1A703C3B231FB14800EDF2C6 /* ArraySerializerTests.swift in Sources */,
+				1A703C2F231FAF3600EDF2C6 /* DynVecSerializerTests.swift in Sources */,
+				1A703C43231FB1AA00EDF2C6 /* UnionSerializerTests.swift in Sources */,
 				1A2D6B3D22A35C6400724E66 /* Blake2bTests.swift in Sources */,
 				1A4A4BAF22A6C2EB003DC827 /* WitnessTests.swift in Sources */,
 				1A4A4BAD22A6C154003DC827 /* CellInputTests.swift in Sources */,
@@ -696,14 +825,22 @@
 				1A2D6B3C22A35C6400724E66 /* Secp256k1Tests.swift in Sources */,
 				1A2D6B2522A35C4F00724E66 /* AddressGeneratorTests.swift in Sources */,
 				1A4A4BBB22A6D152003DC827 /* APIRequestTests.swift in Sources */,
+				1A703C37231FAF9900EDF2C6 /* StructSerializerTests.swift in Sources */,
 				1A4A4BB322A6C5F0003DC827 /* APIErrorTests.swift in Sources */,
 				1A2D6B3822A35C5A00724E66 /* APIMockingTests.swift in Sources */,
+				1A703C2D231FAF2400EDF2C6 /* FixVecSerializerTests.swift in Sources */,
 				1A4A4BAB22A6BF40003DC827 /* CellOutputTests.swift in Sources */,
+				1A703C3F231FB17900EDF2C6 /* OptionSerializerTests.swift in Sources */,
 				1A4A4BB722A6CA4C003DC827 /* APIMockingClientTests.swift in Sources */,
 				1A2D6B2422A35C4F00724E66 /* UtilsTests.swift in Sources */,
 				1A2D6B3922A35C5D00724E66 /* ScriptTests.swift in Sources */,
+				1A36097623228B6C000E67EE /* TransactionSerializerTests.swift in Sources */,
 				1A2D6B3722A35C5A00724E66 /* APIClientTests.swift in Sources */,
+				1A2F5FB72321F1FE000051CC /* SerializerTests.swift in Sources */,
 				1A2D6B2622A35C4F00724E66 /* SystemScriptTests.swift in Sources */,
+				1A703C33231FAF6300EDF2C6 /* TableSerializerTests.swift in Sources */,
+				1A85455123212A5B00B26DC0 /* ByteSerializerTests.swift in Sources */,
+				1A36097423228B22000E67EE /* ScriptSerializerTests.swift in Sources */,
 				1A2D6B2722A35C5300724E66 /* TransactionSignTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -718,6 +855,7 @@
 				1AD96320228D24FB00684FBB /* SystemScript.swift in Sources */,
 				1A11347E2228D14300840EE8 /* Node.swift in Sources */,
 				1A414A7B21C22A9300B28C09 /* APIClient.swift in Sources */,
+				1A703C2B231FAF1000EDF2C6 /* FixVecSerializer.swift in Sources */,
 				1AB7516E22BA0F7100AC9F63 /* AlertMessage.swift in Sources */,
 				1AB45ED7222AA558009B395B /* Secp256k1.swift in Sources */,
 				1A5BCBB3228C571200157426 /* Transaction+Sign.swift in Sources */,
@@ -726,27 +864,41 @@
 				1A2CDAE1228171180024CA71 /* Epoch.swift in Sources */,
 				1A414A8E21C3722300B28C09 /* CellInput.swift in Sources */,
 				1AA9B6862283CE4500C116B2 /* PeerState.swift in Sources */,
+				1A85454F23212A4100B26DC0 /* ByteSerializer.swift in Sources */,
 				1AB7517022BA263C00AC9F63 /* APIClient+Indexer.swift in Sources */,
+				1A2F5FBB23223DF1000051CC /* TransactionSerializer.swift in Sources */,
 				1AE7C62C2251BCA9003FA254 /* Witness.swift in Sources */,
 				1A199DEB22BA3225000C0C34 /* LockHashIndexState.swift in Sources */,
+				1A36096B2322853F000E67EE /* CellOutputSerializer.swift in Sources */,
 				1A414A9621C37AA000B28C09 /* Script.swift in Sources */,
 				1AB7516822B9F2DB00AC9F63 /* APIClient+Pool.swift in Sources */,
 				1AA3B84222EEBB4800027520 /* BlockReward.swift in Sources */,
 				1AA3B83F22EEBAFA00027520 /* BannedAddress.swift in Sources */,
 				1AD3195D225DBA0B00F41790 /* AddressGenerator.swift in Sources */,
+				1A36096F23228979000E67EE /* CellInputSerializer.swift in Sources */,
 				1A414AA021C770DD00B28C09 /* Utils.swift in Sources */,
 				1A4AEBDB2282EB0100F0D576 /* TxPoolInfo.swift in Sources */,
 				1A414A9A21C3879500B28C09 /* Cell.swift in Sources */,
 				1A414A8C21C3714E00B28C09 /* Transaction.swift in Sources */,
+				1A703C39231FB13800EDF2C6 /* ArraySerializer.swift in Sources */,
 				1AB7516A22B9F30200AC9F63 /* APIClient+Stats.swift in Sources */,
+				1A703C35231FAF8600EDF2C6 /* StructSerializer.swift in Sources */,
 				1A2188742288FC1700F613CF /* DryRunResult.swift in Sources */,
+				1A36096D23228675000E67EE /* CellDepSerializer.swift in Sources */,
 				1AB7516622B9F2A100AC9F63 /* APIClient+Net.swift in Sources */,
 				1AD3195F225DBCB300F41790 /* Network.swift in Sources */,
+				1A703C29231FAEF800EDF2C6 /* DynVecSerializer.swift in Sources */,
+				1A36097123228ADF000E67EE /* OutPointSerializer.swift in Sources */,
 				1A414A9021C3723E00B28C09 /* CellOutput.swift in Sources */,
 				1A1C826A222F5D5D0053EC32 /* Blake2b.swift in Sources */,
+				1A703C31231FAF5900EDF2C6 /* TableSerializer.swift in Sources */,
+				1A703C47232085CC00EDF2C6 /* Serializer.swift in Sources */,
 				1A414A8A21C36FE900B28C09 /* Block.swift in Sources */,
 				1A414A9421C3789000B28C09 /* Primitives.swift in Sources */,
+				1A703C41231FB19A00EDF2C6 /* UnionSerializer.swift in Sources */,
+				1A2F5FB923223D9F000051CC /* ScriptSerializer.swift in Sources */,
 				1A414A8321C334EB00B28C09 /* APIRequest.swift in Sources */,
+				1A703C3D231FB16C00EDF2C6 /* OptionSerializer.swift in Sources */,
 				1A4A4BB522A6C64B003DC827 /* APIError.swift in Sources */,
 				1A38CA6422768E7900BEA1F3 /* APIMockingClient.swift in Sources */,
 				1A414A8121C32D4B00B28C09 /* APIResult.swift in Sources */,

--- a/Examples/Example-iOS/Example-iOS/ViewController.swift
+++ b/Examples/Example-iOS/Example-iOS/ViewController.swift
@@ -96,13 +96,13 @@ private extension ViewController {
 
         // Generate lock script for the receiver's address
         let toAddress = "ckt..."
-        let addressHash = Utils.prefixHex(AddressGenerator(network: .testnet).publicKeyHash(for: toAddress)!)
-        let lockScript = Script(args: [addressHash], codeHash: systemScript.secp256k1TypeHash, hashType: .type)
+        let publicKeyHash = Utils.prefixHex(AddressGenerator(network: .testnet).publicKeyHash(for: toAddress)!)
+        let lockScript = systemScript.lock(for: publicKeyHash)
         // Construct the outputs
         let outputs = [CellOutput(capacity: 500_00_000_000.description, lock: lockScript, type: nil)]
 
         // Generate the transaction
-        let tx = Transaction(cellDeps: deps, inputs: inputs, outputs: outputs, witnesses: [Witness(data: [])])
+        let tx = Transaction(cellDeps: deps, inputs: inputs, outputs: outputs, outputsData: ["0x"], witnesses: [Witness(data: [])])
         // For now we need to call the `computeTransactionHash` to get the tx hash
         let apiClient = APIClient(url: nodeUrl)
         let txHash = try apiClient.computeTransactionHash(transaction: tx)
@@ -110,6 +110,6 @@ private extension ViewController {
 
         // Now send out the capacity
         let hash = try apiClient.sendTransaction(transaction: signedTx)
-        print(hash) // hash should equal to txHash
+        print(hash) // hash should be equal to txHash
     }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - CryptoSwift (1.0.0)
   - secp256k1.swift (0.1.4)
   - Sodium (0.8.0)
-  - SwiftLint (0.33.0)
+  - SwiftLint (0.34.0)
 
 DEPENDENCIES:
   - CryptoSwift (~> 1.0.0)
@@ -21,7 +21,7 @@ SPEC CHECKSUMS:
   CryptoSwift: d81eeaa59dc5a8d03720fe919a6fd07b51f7439f
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   Sodium: 63c0ca312a932e6da481689537d4b35568841bdc
-  SwiftLint: fed9c66336e41fc74dc48a73678380718f0c8b0e
+  SwiftLint: 79d48a17c6565dc286c37efb8322c7b450f95c67
 
 PODFILE CHECKSUM: 5c4c4a4a60743a7925b0294f5a96868be334a95c
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ print(height)                                  // "10420"
 ### Send Capacity Example
 
 ```swift
+// Fetch system script which we'll use to generate lock for address
 let systemScript = try SystemScript.loadSystemScript(nodeUrl: nodeUrl)
 // Fill in the sender's private key
 let privateKey: Data = Data(hex: "your private key (hex string)")
@@ -80,13 +81,13 @@ let inputs: [CellInput] = [/*...*/]
 
 // Generate lock script for the receiver's address
 let toAddress = "ckt..."
-let addressHash = Utils.prefixHex(AddressGenerator(network: .testnet).publicKeyHash(for: toAddress)!)
-let lockScript = Script(args: [addressHash], codeHash: systemScript.secp256k1TypeHash, hashType: .type)
+let publicKeyHash = Utils.prefixHex(AddressGenerator(network: .testnet).publicKeyHash(for: toAddress)!)
+let lockScript = systemScript.lock(for: publicKeyHash)
 // Construct the outputs
 let outputs = [CellOutput(capacity: 500_00_000_000.description, lock: lockScript, type: nil)]
 
 // Generate the transaction
-let tx = Transaction(cellDeps: deps, inputs: inputs, outputs: outputs, witnesses: [Witness(data: [])])
+let tx = Transaction(cellDeps: deps, inputs: inputs, outputs: outputs, outputsData: ["0x"], witnesses: [Witness(data: [])])
 // For now we need to call the `computeTransactionHash` to get the tx hash
 let apiClient = APIClient(url: nodeUrl)
 let txHash = try apiClient.computeTransactionHash(transaction: tx)
@@ -94,7 +95,7 @@ let signedTx = try Transaction.sign(tx: tx, with: privateKey, txHash: txHash)
 
 // Now send out the capacity
 let hash = try apiClient.sendTransaction(transaction: signedTx)
-print(hash) // hash should equal to txHash
+print(hash) // hash should be equal to txHash
 ```
 
 ## Getting Help

--- a/Source/Crypto/Blake2b.swift
+++ b/Source/Crypto/Blake2b.swift
@@ -37,4 +37,10 @@ public final class Blake2b {
 
         return Data(output)
     }
+
+    // Hash and return H256 hex string
+    public func hash(bytes: [UInt8]) -> H256 {
+        let hashed = Blake2b().hash(bytes: bytes)!.toHexString()
+        return Utils.prefixHex(hashed)
+    }
 }

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.19.0</string>
+	<string>0.20.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Source/Serialization/BaseSerializers/ArraySerializer.swift
+++ b/Source/Serialization/BaseSerializers/ArraySerializer.swift
@@ -1,0 +1,42 @@
+//
+//  ArraySerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+/// The array is a fixed-size type: it has a fixed-size inner type and a fixed length.
+/// The size of an array is the size of inner type times the length.
+struct ArraySerializer<Item, ItemSerializer>: ObjectSerializer
+    where ItemSerializer: ObjectSerializer, Item == ItemSerializer.ObjectType {
+    typealias ObjectType = [Item]
+
+    private var items: [Item]
+
+    var header: [Byte] {
+        return []
+    }
+
+    var body: [Byte] {
+        return items.flatMap { ItemSerializer.init(value: $0).serialize() }
+    }
+
+    init(value: [Item]) {
+        items = value
+    }
+}
+
+// 32 bytes, good for H256 (hash values)
+typealias Byte32Serializer = ArraySerializer<Byte, ByteSerializer>
+extension Byte32Serializer {
+    // BUGBUGBUG: This would affect normal ArraySerializer<Byte, ByteSerializer>!
+    init?(value: HexString) {
+        let data = Data(hex: value).bytes
+        guard data.count == 32 else {
+            // TODO: Left padding?
+            return nil
+        }
+        self.init(value: data)
+    }
+}

--- a/Source/Serialization/BaseSerializers/ByteSerializer.swift
+++ b/Source/Serialization/BaseSerializers/ByteSerializer.swift
@@ -1,0 +1,31 @@
+//
+//  ByteSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+struct ByteSerializer: ObjectSerializer {
+    typealias ObjectType = Byte
+    private let byte: Byte
+
+    var header: [Byte] {
+        return []
+    }
+
+    var body: [Byte] {
+        return [byte]
+    }
+
+    init(value: Byte) {
+        byte = value
+    }
+
+    init?(value: String) {
+        guard let byte = Byte(value) else {
+            return nil
+        }
+        self.init(value: byte)
+    }
+}

--- a/Source/Serialization/BaseSerializers/DynVecSerializer.swift
+++ b/Source/Serialization/BaseSerializers/DynVecSerializer.swift
@@ -1,0 +1,51 @@
+//
+//  DynVecSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+/// Vector with non-fixed size inner items.
+struct DynVecSerializer<Item, ItemSerializer>: ObjectSerializer
+    where ItemSerializer: ObjectSerializer, Item == ItemSerializer.ObjectType {
+    private var items: [Item]
+
+    private var serializedBody = [Byte]()
+    private var offsets = [UInt32]()
+    private var headerSize: UInt32 {
+        return UInt32((1 + items.count) * MemoryLayout<UInt32>.size)
+    }
+    private var bytesSize: UInt32 {
+        return headerSize + UInt32(body.count)
+    }
+
+    typealias ObjectType = [Item]
+
+    var header: [Byte] {
+        return bytesSize.littleEndianBytes + offsets.flatMap { $0.littleEndianBytes }
+    }
+
+    var body: [Byte] {
+        return serializedBody
+    }
+
+    init(value: [Item]) {
+        items = value
+        preSerialize()
+    }
+
+    // Do not iterate more than once
+    private mutating func preSerialize() {
+        guard items.count > 0 else {
+            return
+        }
+
+        let serialized = items.map { ItemSerializer.init(value: $0).serialize() }
+        offsets.append(headerSize)
+        for serializedItem in serialized.dropLast() {
+            offsets.append(offsets.last! + UInt32(serializedItem.count))
+        }
+        serializedBody = serialized.reduce([], +)
+    }
+}

--- a/Source/Serialization/BaseSerializers/FixVecSerializer.swift
+++ b/Source/Serialization/BaseSerializers/FixVecSerializer.swift
@@ -1,0 +1,30 @@
+//
+//  FixVecSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+/// Vector with fixed size inner items.
+struct FixVecSerializer<Item, ItemSerializer>: ObjectSerializer
+    where ItemSerializer: ObjectSerializer, Item == ItemSerializer.ObjectType {
+    typealias ObjectType = [Item]
+
+    private var items: [Item]
+    private var itemsCount: UInt32 {
+        return UInt32(items.count)
+    }
+
+    var header: [Byte] {
+        return itemsCount.littleEndianBytes
+    }
+
+    var body: [Byte] {
+        return items.flatMap { ItemSerializer.init(value: $0).serialize() }
+    }
+
+    init(value: [Item]) {
+        items = value
+    }
+}

--- a/Source/Serialization/BaseSerializers/OptionSerializer.swift
+++ b/Source/Serialization/BaseSerializers/OptionSerializer.swift
@@ -1,0 +1,33 @@
+//
+//  OptionSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+struct OptionSerializer<T, TSerializer: Serializer>: ObjectSerializer {
+    typealias ObjectType = T?
+    private var value: T?
+    private var serializer: TSerializer?
+
+    var header: [Byte] {
+        return []
+    }
+
+    var body: [Byte] {
+        if value != nil, let serializer = serializer {
+            return serializer.serialize()
+        }
+        return []
+    }
+
+    init(value: T?, serializer: TSerializer? = nil) {
+        self.value = value
+        self.serializer = serializer
+    }
+
+    init(value: T?) {
+        self.init(value: value, serializer: nil)
+    }
+}

--- a/Source/Serialization/BaseSerializers/StructSerializer.swift
+++ b/Source/Serialization/BaseSerializers/StructSerializer.swift
@@ -1,0 +1,32 @@
+//
+//  StructSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+/// The struct is a fixed-size type: all fields in struct are fixed-size and it has a fixed quantity of fields.
+/// The size of a struct is the sum of all fields' size.
+class StructSerializer<T>: ObjectSerializer {
+    typealias ObjectType = T
+    private var value: T
+    private var fieldSerializers: [Serializer]
+
+    var header: [Byte] {
+        return []
+    }
+
+    var body: [Byte] {
+        return fieldSerializers.flatMap { $0.serialize() }
+    }
+
+    required convenience init(value: T) {
+        self.init(value: value, fieldSerializers: [])
+    }
+
+    init(value: T, fieldSerializers: [Serializer]) {
+        self.value = value
+        self.fieldSerializers = fieldSerializers
+    }
+}

--- a/Source/Serialization/BaseSerializers/TableSerializer.swift
+++ b/Source/Serialization/BaseSerializers/TableSerializer.swift
@@ -1,0 +1,56 @@
+//
+//  TableSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+/// The table is a dynamic-size type.
+/// It can be considered as a dynvec but the length is fixed.
+public class TableSerializer<T>: ObjectSerializer {
+    typealias ObjectType = T
+    private var value: T
+    private var fieldSerializers: [Serializer]
+
+    private var serializedBody = [Byte]()
+    private var offsets = [UInt32]()
+    private var headerSize: UInt32 {
+        return UInt32((1 + fieldSerializers.count) * MemoryLayout<UInt32>.size)
+    }
+    private var bytesSize: UInt32 {
+        return headerSize + UInt32(body.count)
+    }
+
+    var header: [Byte] {
+        return bytesSize.littleEndianBytes + offsets.flatMap { $0.littleEndianBytes }
+    }
+
+    var body: [Byte] {
+        return serializedBody
+    }
+
+    required convenience init(value: T) {
+        self.init(value: value, fieldSerializers: [])
+    }
+
+    init(value: T, fieldSerializers: [Serializer]) {
+        self.value = value
+        self.fieldSerializers = fieldSerializers
+        preSerialize()
+    }
+
+    // Do not iterate more than once
+    private func preSerialize() {
+        guard fieldSerializers.count > 0 else {
+            return
+        }
+
+        let serialized = fieldSerializers.map { $0.serialize() }
+        offsets.append(headerSize)
+        for serializedItem in serialized.dropLast() {
+            offsets.append(offsets.last! + UInt32(serializedItem.count))
+        }
+        serializedBody = serialized.reduce([], +)
+    }
+}

--- a/Source/Serialization/BaseSerializers/UnionSerializer.swift
+++ b/Source/Serialization/BaseSerializers/UnionSerializer.swift
@@ -1,0 +1,9 @@
+//
+//  UnionSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+/// Not implemented and used yet

--- a/Source/Serialization/Serializer.swift
+++ b/Source/Serialization/Serializer.swift
@@ -1,0 +1,72 @@
+//
+//  Serializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+// [CKB Serialization RFC](https://github.com/yangby-cryptape/rfcs/blob/pr/serialization/rfcs/0008-serialization/0008-serialization.md)
+// [CKB Types serialization schema](https://github.com/nervosnetwork/ckb/blob/develop/util/types/schemas/ckb.mol)
+
+// Primitive Type
+typealias Byte = UInt8
+
+protocol Serializer {
+    var header: [Byte] { get }
+    var body: [Byte] { get }
+
+    // Serialize as bytes
+    func serialize() -> [Byte]
+}
+
+extension Serializer {
+    func serialize() -> [Byte] {
+        return header + body
+    }
+}
+
+protocol ObjectSerializer: Serializer {
+    associatedtype ObjectType
+
+    init(value: ObjectType)
+}
+
+extension UnsignedInteger where Self: FixedWidthInteger {
+    var littleEndianBytes: [Byte] {
+        var value = littleEndian
+        let data = Data(bytes: &value, count: MemoryLayout.size(ofValue: value))
+        return data.bytes
+    }
+}
+
+// Unsigned Integer, little-endian
+struct UnsignedIntSerializer<T>: ObjectSerializer where T: UnsignedInteger & FixedWidthInteger {
+    typealias ObjectType = T
+    private let value: T
+
+    var header: [Byte] {
+        return []
+    }
+
+    var body: [Byte] {
+        return value.littleEndianBytes
+    }
+
+    init(value: T) {
+        self.value = value
+    }
+
+    init?(value: Number) {
+        guard let uint = T(value) else {
+            return nil
+        }
+        self.init(value: uint)
+    }
+}
+
+// UInt32 (4 bytes), little-endian
+typealias UInt32Serializer = UnsignedIntSerializer<UInt32>
+
+// UInt64 (8 bytes), little-endian
+typealias UInt64Serializer = UnsignedIntSerializer<UInt64>

--- a/Source/Serialization/TypeSerializers/CellDepSerializer.swift
+++ b/Source/Serialization/TypeSerializers/CellDepSerializer.swift
@@ -1,0 +1,25 @@
+//
+//  CellDepSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+extension DepType {
+    var byte: UInt8 {
+        return self == .code ? 0x0 : 0x1
+    }
+}
+
+final class CellDepSerializer: StructSerializer<CellDep> {
+    required init(value: CellDep) {
+        super.init(
+            value: value,
+            fieldSerializers: [
+                OutPointSerializer(value: value.outPoint),
+                ByteSerializer(value: value.depType.byte)
+            ]
+        )
+    }
+}

--- a/Source/Serialization/TypeSerializers/CellInputSerializer.swift
+++ b/Source/Serialization/TypeSerializers/CellInputSerializer.swift
@@ -1,0 +1,19 @@
+//
+//  CellInputSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+final class CellInputSerializer: StructSerializer<CellInput> {
+    required init(value: CellInput) {
+        super.init(
+            value: value,
+            fieldSerializers: [
+                UInt64Serializer(value: value.since)!,
+                OutPointSerializer(value: value.previousOutput)
+            ]
+        )
+    }
+}

--- a/Source/Serialization/TypeSerializers/CellOutputSerializer.swift
+++ b/Source/Serialization/TypeSerializers/CellOutputSerializer.swift
@@ -1,0 +1,20 @@
+//
+//  CellOutputSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+final class CellOutputSerializer: TableSerializer<CellOutput> {
+    required init(value: CellOutput) {
+        super.init(
+            value: value,
+            fieldSerializers: [
+                UInt64Serializer(value: value.capacity)!,
+                value.lock.serializer,
+                OptionSerializer(value: value.type, serializer: value.type?.serializer as? ScriptSerializer)
+            ]
+        )
+    }
+}

--- a/Source/Serialization/TypeSerializers/OutPointSerializer.swift
+++ b/Source/Serialization/TypeSerializers/OutPointSerializer.swift
@@ -1,0 +1,19 @@
+//
+//  OutPointSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+final class OutPointSerializer: StructSerializer<OutPoint> {
+    required init(value: OutPoint) {
+        super.init(
+            value: value,
+            fieldSerializers: [
+                Byte32Serializer(value: value.txHash)!,
+                UInt32Serializer(value: value.index)!
+            ]
+        )
+    }
+}

--- a/Source/Serialization/TypeSerializers/ScriptSerializer.swift
+++ b/Source/Serialization/TypeSerializers/ScriptSerializer.swift
@@ -1,0 +1,49 @@
+//
+//  ScriptSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+extension ScriptHashType {
+    var byte: UInt8 {
+        return self == .data ? 0x0 : 0x1
+    }
+}
+
+public final class ScriptSerializer: TableSerializer<Script> {
+    public required init(value: Script) {
+        let normalizedArgs: [[Byte]] = value.args.map { (arg) in
+            // TODO: check if Data(hex: arg) needs to left pad arg string
+            return Data(hex: arg).bytes
+        }
+        super.init(
+            value: value,
+            fieldSerializers: [
+                Byte32Serializer(value: value.codeHash)!,
+                ByteSerializer(value: value.hashType.byte),
+                DynVecSerializer<[Byte], FixVecSerializer<Byte, ByteSerializer>>(value: normalizedArgs)
+            ]
+        )
+    }
+}
+
+public extension Script {
+    internal var serializer: Serializer {
+        return ScriptSerializer(value: self)
+    }
+
+    func serialize() -> [UInt8] {
+        return serializer.serialize()
+    }
+
+    func computeHash() -> H256 {
+        let serialized = serialize()
+        return Blake2b().hash(bytes: serialized)
+    }
+
+    var hash: H256 {
+        return computeHash()
+    }
+}

--- a/Source/Serialization/TypeSerializers/TransactionSerializer.swift
+++ b/Source/Serialization/TypeSerializers/TransactionSerializer.swift
@@ -1,0 +1,39 @@
+//
+//  TransactionSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+ /// https://github.com/nervosnetwork/ckb/blob/develop/util/types/schemas/ckb.mol#L69
+public final class TransactionSerializer: TableSerializer<Transaction> {
+    public required init(value: Transaction) {
+        let hexStringsToArrayOfBytes: ([HexString]) -> [[Byte]] = { strings in
+            return strings.map { Data(hex: $0).bytes }
+        }
+        super.init(
+            value: value,
+            fieldSerializers: [
+                UInt32Serializer(value: value.version)!,
+                FixVecSerializer<CellDep, CellDepSerializer>(value: value.cellDeps),
+                FixVecSerializer<[Byte], Byte32Serializer>(value: hexStringsToArrayOfBytes(value.headerDeps)),
+                FixVecSerializer<CellInput, CellInputSerializer>(value: value.inputs),
+                DynVecSerializer<CellOutput, CellOutputSerializer>(value: value.outputs),
+                DynVecSerializer<[Byte], FixVecSerializer<Byte, ByteSerializer>>(value: hexStringsToArrayOfBytes(value.outputsData))
+            ]
+        )
+    }
+}
+
+public extension Transaction {
+    func serialize() -> [UInt8] {
+        let serializer = TransactionSerializer(value: self)
+        return serializer.serialize()
+    }
+
+    func computeHash() -> H256 {
+        let serialized = serialize()
+        return Blake2b().hash(bytes: serialized)
+    }
+}

--- a/Source/Types/Script.swift
+++ b/Source/Types/Script.swift
@@ -12,27 +12,14 @@ public enum ScriptHashType: String, Codable {
 }
 
 public struct Script: Codable, Param {
-    public let args: [HexString]
     public let codeHash: H256
     public let hashType: ScriptHashType
+    public let args: [HexString]
 
     enum CodingKeys: String, CodingKey {
-        case args
         case codeHash = "code_hash"
         case hashType = "hash_type"
-    }
-
-    // Before serialization is implemented _compute_script_hash RPC should be used instead.
-    public var hash: String {
-        #warning("This needs re-implementation when serialization is applied.")
-        var bytes = [UInt8]()
-        bytes.append(contentsOf: Data(hex: codeHash).bytes)
-        bytes.append(hashType == .data ? 0x0 : 0x1)
-        args.forEach { (arg) in
-            bytes.append(contentsOf: Data(hex: arg).bytes)
-        }
-        let hash = Blake2b().hash(bytes: bytes)!
-        return Utils.prefixHex(Data(hash).toHexString())
+        case args
     }
 
     public var param: [String: Any] {
@@ -44,8 +31,8 @@ public struct Script: Codable, Param {
     }
 
     public init(args: [HexString] = [], codeHash: H256 = H256.zeroHash, hashType: ScriptHashType = .data) {
-        self.args = args
         self.codeHash = Utils.prefixHex(codeHash)
         self.hashType = hashType
+        self.args = args
     }
 }

--- a/Source/Utils/SystemScript.swift
+++ b/Source/Utils/SystemScript.swift
@@ -27,8 +27,7 @@ public struct SystemScript {
         guard systemCellTransaction.outputs.count >= 2, let type = systemCellTransaction.outputs[1].type else {
             throw APIError.genericError("Fail to fetch system cell tx from genesis block.")
         }
-        // TODO: Switch to Script.hash when that's added after serialization/hash change
-        let secp256k1TypeHash = try client.computeScriptHash(script: type)
+        let secp256k1TypeHash = type.hash
 
         let depOutPoint = OutPoint(txHash: genesisBlock.transactions[1].hash, index: "0")
 

--- a/Source/Utils/SystemScript.swift
+++ b/Source/Utils/SystemScript.swift
@@ -34,4 +34,13 @@ public struct SystemScript {
 
         return SystemScript(depOutPoint: depOutPoint, secp256k1TypeHash: secp256k1TypeHash)
     }
+
+    public func lock(for publicKey: Data) -> Script {
+        let publicKeyHash = Utils.prefixHex(AddressGenerator().hash(for: publicKey).toHexString())
+        return lock(for: publicKeyHash)
+    }
+
+    public func lock(for publicKeyHash: String) -> Script {
+        return Script(args: [publicKeyHash], codeHash: secp256k1TypeHash, hashType: .type)
+    }
 }

--- a/Tests/API/APIClientTests.swift
+++ b/Tests/API/APIClientTests.swift
@@ -173,15 +173,15 @@ class APIClientTests: RPCTestSkippable {
 
     func testComputeTransactionHash() throws {
         let tx = Transaction(
-            cellDeps: [CellDep(outPoint: OutPoint(txHash: "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452", index: "0"), depType: .code)],
-            headerDeps: ["0xb877a54927a2cc36f455533160f65025c0066a3a371a81be2a9bb75554abcc43"],
-            inputs: [CellInput(previousOutput: OutPoint(txHash: "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3", index: "0"), since: "0")],
+            cellDeps: [CellDep(outPoint: OutPoint(txHash: "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141", index: "0"), depType: .code)],
+            headerDeps: ["0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"],
+            inputs: [CellInput(previousOutput: OutPoint(txHash: "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17", index: "0"), since: "0")],
             outputs: [CellOutput(capacity: "100000000000", lock: Script(args: [], codeHash: "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5", hashType: .data))],
             outputsData: ["0x"]
         )
         let result = try client.computeTransactionHash(transaction: tx)
         XCTAssertNotNil(result)
-        XCTAssertEqual("0x45746b0f98b11fa67c88b66ac61044238af6f1e69f0006c690998fbe0cc96878", result)
+        XCTAssertEqual("0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece", result)
     }
 
     func testComputeScriptHash() throws {

--- a/Tests/API/APIMockingTests.swift
+++ b/Tests/API/APIMockingTests.swift
@@ -132,15 +132,15 @@ class APIMockingTests: XCTestCase {
 
     func testComputeTransactionHash() throws {
         let tx = Transaction(
-            cellDeps: [CellDep(outPoint: OutPoint(txHash: "0xca457e8f2babbced0321daa535d5d357f554ff601a164c3ce76b547fd5ad2452", index: "0"), depType: .code)],
-            headerDeps: ["0xb877a54927a2cc36f455533160f65025c0066a3a371a81be2a9bb75554abcc43"],
-            inputs: [CellInput(previousOutput: OutPoint(txHash: "0xd134dabdb4686abd4e25b0fc95d5b7da5e14efc87e99bd34965571725f6370e3", index: "0"), since: "0")],
+            cellDeps: [CellDep(outPoint: OutPoint(txHash: "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141", index: "0"), depType: .code)],
+            headerDeps: ["0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"],
+            inputs: [CellInput(previousOutput: OutPoint(txHash: "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17", index: "0"), since: "0")],
             outputs: [CellOutput(capacity: "100000000000", lock: Script(args: [], codeHash: "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5", hashType: .data))],
             outputsData: ["0x"]
         )
         let result = try? getClient(json: "computeTransactionHash").computeTransactionHash(transaction: tx)
         XCTAssertNotNil(result)
-        XCTAssertEqual("0x45746b0f98b11fa67c88b66ac61044238af6f1e69f0006c690998fbe0cc96878", result)
+        XCTAssertEqual("0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece", result)
     }
 
     func testComputeScriptHash() throws {

--- a/Tests/API/RPC Fixtures/computeTransactionHash.json
+++ b/Tests/API/RPC Fixtures/computeTransactionHash.json
@@ -1,5 +1,5 @@
 {
     "jsonrpc": "2.0",
-    "result": "0x45746b0f98b11fa67c88b66ac61044238af6f1e69f0006c690998fbe0cc96878",
+    "result": "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece",
     "id": 1
 }

--- a/Tests/Serialization/BaseSerializers/ArraySerializerTests.swift
+++ b/Tests/Serialization/BaseSerializers/ArraySerializerTests.swift
@@ -1,0 +1,40 @@
+//
+//  ArraySerializerTests.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import XCTest
+@testable import CKB
+
+class ArraySerializerTests: XCTestCase {
+    // MARK: - ArraySerializer
+    func testArraySerializer() {
+        let arraySerializer = UnsignedIntSerializer<UInt16>(value: UInt16.max.description)!
+        XCTAssertEqual(arraySerializer.header, [])
+        XCTAssertEqual(arraySerializer.body, [255, 255])
+    }
+
+    func testByte3() {
+        typealias Byte3Serializer = ArraySerializer<Byte, ByteSerializer>
+        XCTAssertEqual(Byte3Serializer(value: [0x01, 0x02, 0x03]).serialize(), [0x01, 0x02, 0x03])
+    }
+
+    func testTwoUint32() {
+        typealias TwoUint32Serializer = ArraySerializer<UInt32, UInt32Serializer>
+        XCTAssertEqual(TwoUint32Serializer(value: [0x01020304, 0xabcde]).serialize(), [0x04, 0x03, 0x02, 0x01, 0xde, 0xbc, 0x0a, 0x00])
+    }
+
+    // MARK: - Byte32Serializer
+    func testByte32Serializer() {
+        let hex = "e79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3"
+        let expected: [Byte] = [231, 159, 50, 7, 234, 73, 128, 183, 254, 215, 153, 86, 213, 147, 66, 73, 206, 172, 71, 81, 164, 250, 224, 26, 15, 124, 74, 150, 136, 75, 196, 227]
+        XCTAssertEqual(Byte32Serializer(value: hex)!.serialize(), expected)
+        XCTAssertEqual(Byte32Serializer(value: Utils.prefixHex(hex))!.serialize(), expected)
+
+        // Too long
+        XCTAssertNil(Byte32Serializer(value: hex + "01"))
+        // Too short
+        XCTAssertNil(Byte32Serializer(value: String(hex.suffix(62))))
+    }
+}

--- a/Tests/Serialization/BaseSerializers/ByteSerializerTests.swift
+++ b/Tests/Serialization/BaseSerializers/ByteSerializerTests.swift
@@ -1,0 +1,20 @@
+//
+//  ByteSerializerTests.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import XCTest
+@testable import CKB
+
+class ByteSerializerTests: XCTestCase {
+    func testByteSerializer() {
+        XCTAssertEqual(ByteSerializer(value: UInt8(255)).serialize(), [255])
+        XCTAssertEqual(ByteSerializer(value: "255")!.serialize(), [255])
+
+        // Overflow
+        XCTAssertNil(ByteSerializer(value: "256"))
+        // Underflow
+        XCTAssertNil(ByteSerializer(value: "-1"))
+    }
+}

--- a/Tests/Serialization/BaseSerializers/DynVecSerializerTests.swift
+++ b/Tests/Serialization/BaseSerializers/DynVecSerializerTests.swift
@@ -1,0 +1,53 @@
+//
+//  DynVecSerializerTests.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import XCTest
+@testable import CKB
+
+class DynVecSerializerTests: XCTestCase {
+    typealias BytesSerializer = FixVecSerializer<Byte, ByteSerializer>
+    typealias BytesVecSerializer = DynVecSerializer<[Byte], BytesSerializer>
+
+    func testEmptyBytesVector() {
+        let emptySerializer = BytesVecSerializer(value: [])
+        XCTAssertEqual(emptySerializer.serialize(), [4, 0, 0, 0])
+    }
+
+    func testOneItemBytesVector() {
+        let oneItemSerializer = BytesVecSerializer(value: [[0x12, 0x34]])
+        XCTAssertEqual(
+            oneItemSerializer.serialize(),
+            [
+                0x0e, 0x00, 0x00, 0x00,
+                0x08, 0x00, 0x00, 0x00,
+                0x02, 0x00, 0x00, 0x00, 0x12, 0x34
+            ]
+        )
+    }
+
+    func testMultiItemsBytesVector() {
+        let collectionOfBytes: [[Byte]] = [
+            [0x12, 0x34],
+            [],
+            [0x05, 0x67],
+            [0x89],
+            [0xab, 0xcd, 0xef]
+        ]
+        let multiItemsSerializer = BytesVecSerializer(value: collectionOfBytes)
+        XCTAssertEqual(
+            multiItemsSerializer.serialize(),
+            [
+                0x34, 0, 0, 0,
+                0x18, 0, 0, 0, 0x1e, 0, 0, 0, 0x22, 0, 0, 0, 0x28, 0, 0, 0, 0x2d, 0, 0, 0,
+                0x02, 0, 0, 0, 0x12, 0x34,
+                0, 0, 0, 0,
+                0x02, 0, 0, 0, 0x05, 0x67,
+                0x01, 0, 0, 0, 0x89,
+                0x03, 0, 0, 0, 0xab, 0xcd, 0xef
+            ]
+        )
+    }
+}

--- a/Tests/Serialization/BaseSerializers/FixVecSerializerTests.swift
+++ b/Tests/Serialization/BaseSerializers/FixVecSerializerTests.swift
@@ -1,0 +1,44 @@
+//
+//  FixVecSerializerTests.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import XCTest
+@testable import CKB
+
+class FixVecSerializerTests: XCTestCase {
+    func testByteVector() {
+        typealias ByteVecSerializer = FixVecSerializer<Byte, ByteSerializer>
+
+        let emptySerializer = ByteVecSerializer(value: [])
+        XCTAssertEqual(emptySerializer.serialize(), [0, 0, 0, 0])
+
+        let oneItemSerializer = ByteVecSerializer(value: [12])
+        XCTAssertEqual(oneItemSerializer.serialize(), [1, 0, 0, 0, 12])
+    }
+
+    func testUint32Vector() {
+        typealias Uint32VecSerializer = FixVecSerializer<UInt32, UInt32Serializer>
+
+        let emptySerializer = Uint32VecSerializer(value: [])
+        XCTAssertEqual(emptySerializer.serialize(), [0, 0, 0, 0])
+
+        let oneItemSerializer = Uint32VecSerializer(value: [0x123])
+        XCTAssertEqual(oneItemSerializer.serialize(), [1, 0, 0, 0, 0x23, 1, 0, 0])
+
+        let sixItemsSerializer = Uint32VecSerializer(value: [0x123, 0x456, 0x7890, 0xa, 0xbc, 0xdef])
+        XCTAssertEqual(
+            sixItemsSerializer.serialize(),
+            [
+                0x06, 0x00, 0x00, 0x00,
+                0x23, 0x01, 0x00, 0x00,
+                0x56, 0x04, 0x00, 0x00,
+                0x90, 0x78, 0x00, 0x00,
+                0x0a, 0x00, 0x00, 0x00,
+                0xbc, 0x00, 0x00, 0x00,
+                0xef, 0x0d, 0x00, 0x00
+            ]
+        )
+    }
+}

--- a/Tests/Serialization/BaseSerializers/OptionSerializerTests.swift
+++ b/Tests/Serialization/BaseSerializers/OptionSerializerTests.swift
@@ -1,0 +1,57 @@
+//
+//  OptionSerializerTests.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import XCTest
+@testable import CKB
+
+class OptionSerializerTests: XCTestCase {
+    struct TableType {
+        var f1: Byte
+        var f2: UInt32
+
+        var serializer: Serializer {
+            return TableSerializer(
+                value: self,
+                fieldSerializers: [
+                    ByteSerializer(value: f1),
+                    UInt32Serializer(value: f2)
+                ]
+            )
+        }
+    }
+
+    func testNonEmptyObject() {
+        let object = TableType(f1: 0x01, f2: 2)
+        let serializer = TableSerializer(
+            value: object,
+            fieldSerializers: [
+                ByteSerializer(value: object.f1),
+                UInt32Serializer(value: object.f2)
+            ]
+        )
+        let optionSerializer = OptionSerializer(value: object, serializer: serializer)
+        XCTAssertEqual(
+            optionSerializer.serialize(),
+            [17, 0, 0, 0, 12, 0, 0, 0, 13, 0, 0, 0, 1, 2, 0, 0, 0]
+        )
+    }
+
+    func testEmptyObject() {
+        let object: TableType? = nil
+        let serializer = TableSerializer(
+            value: object,
+            fieldSerializers: [
+                ByteSerializer(value: 1),
+                UInt32Serializer(value: 2)
+            ]
+        )
+        let optionSerializer = OptionSerializer(value: object, serializer: serializer)
+        XCTAssertEqual(
+            optionSerializer.serialize(),
+            []
+        )
+    }
+}

--- a/Tests/Serialization/BaseSerializers/StructSerializerTests.swift
+++ b/Tests/Serialization/BaseSerializers/StructSerializerTests.swift
@@ -1,0 +1,34 @@
+//
+//  StructSerializerTests.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import XCTest
+@testable import CKB
+
+class StructSerializerTests: XCTestCase {
+    func testOnlyAByte() {
+        struct OnlyAByte { var f1: Byte }
+        let object = OnlyAByte(f1: 0xab)
+        let onlyAByteSerializer = StructSerializer(value: object, fieldSerializers: [ByteSerializer(value: object.f1)])
+        XCTAssertEqual([Byte(0xab)], onlyAByteSerializer.serialize())
+    }
+
+    func testByteAndUint32() {
+        struct ByteAndUint32 {
+            var f1: Byte
+            var f2: UInt32
+        }
+        let object = ByteAndUint32(f1: 0xab, f2: 0x010203)
+        let byteAndUint32Serializer = StructSerializer(
+            value: object,
+            fieldSerializers: [
+                ByteSerializer(value: object.f1),
+                UInt32Serializer(value: object.f2)
+            ]
+        )
+        let expected: [Byte] = [0xab, 0x03, 0x02, 0x01, 0x00]
+        XCTAssertEqual(expected, byteAndUint32Serializer.serialize())
+    }
+}

--- a/Tests/Serialization/BaseSerializers/TableSerializerTests.swift
+++ b/Tests/Serialization/BaseSerializers/TableSerializerTests.swift
@@ -1,0 +1,53 @@
+//
+//  TableSerializerTests.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import XCTest
+@testable import CKB
+
+class TableSerializerTests: XCTestCase {
+    func testTableSerializer() {
+        typealias Bytes = [Byte]
+        typealias Byte3 = [Byte]
+        typealias BytesSerializer = FixVecSerializer<Byte, ByteSerializer>
+
+        struct MixedType {
+            var f1: Bytes
+            var f2: Byte
+            var f3: UInt32
+            var f4: Byte3
+            var f5: Bytes
+        }
+        let object = MixedType(
+            f1: [],
+            f2: 0xab,
+            f3: 0x123,
+            f4: [0x45, 0x67, 0x89],
+            f5: [0xab, 0xcd, 0xef]
+        )
+        let serializer = TableSerializer(
+            value: object,
+            fieldSerializers: [
+                BytesSerializer(value: object.f1),
+                ByteSerializer(value: object.f2),
+                UInt32Serializer(value: object.f3),
+                ArraySerializer<Byte, ByteSerializer>(value: object.f4),
+                BytesSerializer(value: object.f5)
+            ]
+        )
+        XCTAssertEqual(
+            serializer.serialize(),
+            [
+                0x2b, 0, 0, 0,
+                0x18, 0, 0, 0, 0x1c, 0, 0, 0, 0x1d, 0, 0, 0, 0x21, 0, 0, 0, 0x24, 0, 0, 0,
+                0, 0, 0, 0,
+                0xab,
+                0x23, 0x01, 0, 0,
+                0x45, 0x67, 0x89,
+                0x03, 0, 0, 0, 0xab, 0xcd, 0xef
+            ]
+        )
+    }
+}

--- a/Tests/Serialization/BaseSerializers/UnionSerializerTests.swift
+++ b/Tests/Serialization/BaseSerializers/UnionSerializerTests.swift
@@ -1,0 +1,10 @@
+//
+//  UnionSerializerTests.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import XCTest
+
+class UnionSerializerTests: XCTestCase {
+}

--- a/Tests/Serialization/SerializerTests.swift
+++ b/Tests/Serialization/SerializerTests.swift
@@ -1,0 +1,47 @@
+//
+//  SerializerTests.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import XCTest
+@testable import CKB
+
+class SerializerTests: XCTestCase {
+    func testUIntLittleEndianBytes() {
+        XCTAssertEqual(UInt16.max.littleEndianBytes, [255, 255])
+        XCTAssertEqual(UInt16(1).littleEndianBytes, [1, 0])
+
+        XCTAssertEqual(UInt32.max.littleEndianBytes, [UInt8](repeating: 255, count: 4))
+        XCTAssertEqual(UInt32(1).littleEndianBytes, [1, 0, 0, 0])
+
+        XCTAssertEqual(UInt64.max.littleEndianBytes, [UInt8](repeating: 255, count: 8))
+        XCTAssertEqual(UInt64(1).littleEndianBytes, [1, 0, 0, 0, 0, 0, 0, 0])
+    }
+
+    // MARK: - UInt32Serializer
+    func testUInt32Serializer() {
+        // 0x01020304
+        let expected: [Byte] = [4, 3, 2, 1]
+        XCTAssertEqual(UInt32Serializer(value: 16909060).serialize(), expected)
+        XCTAssertEqual(UInt32Serializer(value: "16909060")!.serialize(), expected)
+
+        // Overflow
+        XCTAssertNil(UInt32Serializer(value: (UInt64(UInt32.max) + 1).description))
+        // Underflow
+        XCTAssertNil(UInt32Serializer(value: "-1"))
+    }
+
+    // MARK: - UInt64Serializer
+    func testUInt64Serializer() {
+        let max = UInt64.max
+        let expected: [Byte] = [Byte](repeating: 255, count: 8)
+        XCTAssertEqual(UInt64Serializer(value: max).serialize(), expected)
+        XCTAssertEqual(UInt64Serializer(value: max.description)!.serialize(), expected)
+
+        // Overflow
+        XCTAssertNil(UInt64Serializer(value: UInt64.max.description + "1"))
+        // Underflow
+        XCTAssertNil(UInt64Serializer(value: "-1"))
+    }
+}

--- a/Tests/Serialization/TypeSerializers/ScriptSerializerTests.swift
+++ b/Tests/Serialization/TypeSerializers/ScriptSerializerTests.swift
@@ -1,0 +1,53 @@
+//
+//  ScriptSerializerTests.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import XCTest
+@testable import CKB
+
+class ScriptSerializerTests: XCTestCase {
+    func testEmptyScriptHash() {
+        let script = Script()
+        XCTAssertEqual("0xbd7e6000ffb8e983a6023809037e0c4cedbc983637c46d74621fd28e5f15fe4f", script.hash)
+    }
+
+    func testDataScriptHash() {
+        let script = Script(
+            args: [],
+            codeHash: "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+            hashType: .data
+        )
+        XCTAssertEqual("0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9", script.hash)
+    }
+
+    func testTypeScriptHash() {
+        let script = Script(
+            args: ["0x3954acece65096bfa81258983ddb83915fc56bd8"],
+            codeHash: "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
+            hashType: .type
+        )
+        XCTAssertEqual("0xb1ed7d4f2b8a22866391121c504ee88bc1a800024d7aef5fd4219a3cb1c90cb3", script.hash)
+    }
+
+    func testScriptHashWithZeroCodeHash() {
+        let script = Script(
+            args: ["0x01"],
+            codeHash: H256.zeroHash
+        )
+        XCTAssertEqual("0x5a2b913dfb1b79136fc72a575fd8e93ae080b504463c0066fea086482bfc3a94", script.hash)
+    }
+
+    func testSerialize() {
+        let script = Script(
+            args: ["0x3954acece65096bfa81258983ddb83915fc56bd8"],
+            codeHash: "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
+            hashType: .type
+        )
+        XCTAssertEqual(
+            "5100000010000000300000003100000068d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88012000000008000000140000003954acece65096bfa81258983ddb83915fc56bd8",
+            script.serialize().toHexString()
+        )
+    }
+}

--- a/Tests/Serialization/TypeSerializers/TransactionSerializerTests.swift
+++ b/Tests/Serialization/TypeSerializers/TransactionSerializerTests.swift
@@ -1,0 +1,54 @@
+//
+//  TransactionSerializerTests.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import XCTest
+@testable import CKB
+
+class TransactionSerializerTests: XCTestCase {
+    func testTransaction() {
+        let tx = Transaction(
+            version: "0",
+            cellDeps: [
+                CellDep(outPoint: OutPoint(txHash: "0xbffab7ee0a050e2cb882de066d3dbf3afdd8932d6a26eda44f06e4b23f0f4b5a", index: "0"), depType: .code)
+            ],
+            outputs: [
+                CellOutput(
+                    capacity: "100000000000",
+                    lock: Script(args: ["0xe2193df51d78411601796b35b17b4f8f2cd85bd0"], codeHash: "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08"),
+                    type: nil
+                ),
+                CellOutput(
+                    capacity: "4900000000000",
+                    lock: Script(args: ["0x36c329ed630d6ce750712a477543672adab57f4c"], codeHash: "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08"),
+                    type: nil
+                )
+            ],
+            outputsData: [
+                "0x",
+                "0x"
+            ],
+            witnesses: [
+                Witness(data: [])
+            ]
+        )
+        XCTAssertEqual(tx.computeHash(), "0xc932addf21edeac2fdd4d677f3984688ee5514c87412087c6bb533bf96e4e624")
+        // let hash = try? APIClient(url: APIClient.defaultLocalURL).computeTransactionHash(transaction: tx)
+        // XCTAssertEqual(tx.computeHash(), hash)
+    }
+
+    func testTransactionWithInputs() {
+        let tx = Transaction(
+            cellDeps: [CellDep(outPoint: OutPoint(txHash: "0x29f94532fb6c7a17f13bcde5adb6e2921776ee6f357adf645e5393bd13442141", index: "0"), depType: .code)],
+            headerDeps: ["0x8033e126475d197f2366bbc2f30b907d15af85c9d9533253c6f0787dcbbb509e"],
+            inputs: [CellInput(previousOutput: OutPoint(txHash: "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17", index: "0"), since: "0")],
+            outputs: [CellOutput(capacity: "100000000000", lock: Script(args: [], codeHash: "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5", hashType: .data))],
+            outputsData: ["0x"]
+        )
+        XCTAssertEqual(tx.computeHash(), "0xba86cc2cb21832bf4a84c032eb6e8dc422385cc8f8efb84eb0bc5fe0b0b9aece")
+        // let hash = try? APIClient(url: APIClient.defaultLocalURL).computeTransactionHash(transaction: tx)
+        // XCTAssertEqual(tx.computeHash(), hash)
+    }
+}

--- a/Tests/Types/ScriptTests.swift
+++ b/Tests/Types/ScriptTests.swift
@@ -8,29 +8,6 @@ import XCTest
 @testable import CKB
 
 class ScriptTests: XCTestCase {
-    func testEmptyScriptHash() {
-        let script = Script()
-        XCTAssertEqual("0xc371c8d6a0aed6018e91202d047c35055cfb0228e6709f1cd1d5f756525628b9", script.hash)
-    }
-
-    // TODO: Enable this test after script serialization is implemented
-    func _testScriptHash() {
-        let script = Script(
-            args: [],
-            codeHash: "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
-            hashType: .data
-        )
-        XCTAssertEqual("0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9", script.hash)
-    }
-
-    func testScriptHashWithZeroCodeHash() {
-        let script = Script(
-            args: ["0x01"],
-            codeHash: H256.zeroHash
-        )
-        XCTAssertEqual("0xcd5b0c29b8f5528d3a75e3918576db4d962a1d4b315dff7d3c50818cc373b3f5", script.hash)
-    }
-
     func testCodeHashHasPrefix() {
         let codeHash = Utils.prefixHex(H256.zeroHash)
         let script = Script(codeHash: H256(codeHash.dropFirst(2)))

--- a/Tests/Utils/SystemScriptTests.swift
+++ b/Tests/Utils/SystemScriptTests.swift
@@ -19,8 +19,7 @@ class SystemScriptTests: RPCTestSkippable {
         let publicKey = Utils.privateToPublic(privateKey)
         let systemScript = try SystemScript.loadSystemScript(nodeUrl: APIClient.defaultLocalURL)
         let lockScript = systemScript.lock(for: publicKey)
-        let lockHash = try APIClient(url: APIClient.defaultLocalURL).computeScriptHash(script: lockScript)
-        // let lockHash = lockScript.hash // TODO: Switch to this after serialization implemented
+        let lockHash = lockScript.hash
         XCTAssertEqual("0xecaeea8c8581d08a3b52980272001dbf203bc6fa2afcabe7cc90cc2afff488ba", lockHash)
     }
 
@@ -28,8 +27,7 @@ class SystemScriptTests: RPCTestSkippable {
         let systemScript = try SystemScript.loadSystemScript(nodeUrl: APIClient.defaultLocalURL)
         let publicKeyHash = "0x36c329ed630d6ce750712a477543672adab57f4c"
         let lockScript = systemScript.lock(for: publicKeyHash)
-        let lockHash = try APIClient(url: APIClient.defaultLocalURL).computeScriptHash(script: lockScript)
-        // let lockHash = lockScript.hash // TODO: Switch to this after serialization implemented
+        let lockHash = lockScript.hash
         XCTAssertEqual("0xecaeea8c8581d08a3b52980272001dbf203bc6fa2afcabe7cc90cc2afff488ba", lockHash)
     }
 }

--- a/Tests/Utils/SystemScriptTests.swift
+++ b/Tests/Utils/SystemScriptTests.swift
@@ -13,4 +13,23 @@ class SystemScriptTests: RPCTestSkippable {
         XCTAssertNotNil(systemScript)
         XCTAssertEqual("0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88", systemScript.secp256k1TypeHash)
     }
+
+    func testPublicKeyToScript() throws {
+        let privateKey = Data(hex: "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3")
+        let publicKey = Utils.privateToPublic(privateKey)
+        let systemScript = try SystemScript.loadSystemScript(nodeUrl: APIClient.defaultLocalURL)
+        let lockScript = systemScript.lock(for: publicKey)
+        let lockHash = try APIClient(url: APIClient.defaultLocalURL).computeScriptHash(script: lockScript)
+        // let lockHash = lockScript.hash // TODO: Switch to this after serialization implemented
+        XCTAssertEqual("0x024b0fd0c4912e98aab6808f6474cacb1969255d526b3cac5d3bdd15962a8818", lockHash)
+    }
+
+    func testPublicKeyHashToScript() throws {
+        let systemScript = try SystemScript.loadSystemScript(nodeUrl: APIClient.defaultLocalURL)
+        let publicKeyHash = "0x36c329ed630d6ce750712a477543672adab57f4c"
+        let lockScript = systemScript.lock(for: publicKeyHash)
+        let lockHash = try APIClient(url: APIClient.defaultLocalURL).computeScriptHash(script: lockScript)
+        // let lockHash = lockScript.hash // TODO: Switch to this after serialization implemented
+        XCTAssertEqual("0x024b0fd0c4912e98aab6808f6474cacb1969255d526b3cac5d3bdd15962a8818", lockHash)
+    }
 }

--- a/Tests/Utils/SystemScriptTests.swift
+++ b/Tests/Utils/SystemScriptTests.swift
@@ -11,7 +11,7 @@ class SystemScriptTests: RPCTestSkippable {
     func testLoadSystemScript() throws {
         let systemScript = try SystemScript.loadSystemScript(nodeUrl: APIClient.defaultLocalURL)
         XCTAssertNotNil(systemScript)
-        XCTAssertEqual("0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88", systemScript.secp256k1TypeHash)
+        XCTAssertEqual("0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2", systemScript.secp256k1TypeHash)
     }
 
     func testPublicKeyToScript() throws {
@@ -21,7 +21,7 @@ class SystemScriptTests: RPCTestSkippable {
         let lockScript = systemScript.lock(for: publicKey)
         let lockHash = try APIClient(url: APIClient.defaultLocalURL).computeScriptHash(script: lockScript)
         // let lockHash = lockScript.hash // TODO: Switch to this after serialization implemented
-        XCTAssertEqual("0x024b0fd0c4912e98aab6808f6474cacb1969255d526b3cac5d3bdd15962a8818", lockHash)
+        XCTAssertEqual("0xecaeea8c8581d08a3b52980272001dbf203bc6fa2afcabe7cc90cc2afff488ba", lockHash)
     }
 
     func testPublicKeyHashToScript() throws {
@@ -30,6 +30,6 @@ class SystemScriptTests: RPCTestSkippable {
         let lockScript = systemScript.lock(for: publicKeyHash)
         let lockHash = try APIClient(url: APIClient.defaultLocalURL).computeScriptHash(script: lockScript)
         // let lockHash = lockScript.hash // TODO: Switch to this after serialization implemented
-        XCTAssertEqual("0x024b0fd0c4912e98aab6808f6474cacb1969255d526b3cac5d3bdd15962a8818", lockHash)
+        XCTAssertEqual("0xecaeea8c8581d08a3b52980272001dbf203bc6fa2afcabe7cc90cc2afff488ba", lockHash)
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
       sdk: 'macosx10.14'
       configuration: 'Debug'
       skip_rpc_tests: 0
-      ckb_version: 'v0.19.2'
+      ckb_version: 'v0.20.0-pre1'
     steps:
       - task: CocoaPods@0
         displayName: 'pod install using the CocoaPods task with defaults'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
       sdk: 'macosx10.14'
       configuration: 'Debug'
       skip_rpc_tests: 0
-      ckb_version: 'v0.20.0-pre1'
+      ckb_version: 'v0.20.0-rc1'
     steps:
       - task: CocoaPods@0
         displayName: 'pod install using the CocoaPods task with defaults'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
       sdk: 'macosx10.14'
       configuration: 'Debug'
       skip_rpc_tests: 0
-      ckb_version: 'v0.19.1'
+      ckb_version: 'v0.19.2'
     steps:
       - task: CocoaPods@0
         displayName: 'pod install using the CocoaPods task with defaults'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
       sdk: 'macosx10.14'
       configuration: 'Debug'
       skip_rpc_tests: 0
-      ckb_version: 'v0.20.0-rc1'
+      ckb_version: 'v0.20.0'
     steps:
       - task: CocoaPods@0
         displayName: 'pod install using the CocoaPods task with defaults'


### PR DESCRIPTION
## TODO

- [x] Merge `develop` after serialization feature is done
- [x] Bump CKB binary version
- [x] Update changelog

# [v0.20.0](https://github.com/nervosnetwork/ckb-sdk-swift/compare/v0.19.0...v0.20.0) (2019-09-07)


### Features

* Add public key hash to lock script util ([c4096d2](https://github.com/nervosnetwork/ckb-sdk-swift/commit/c4096d2))
* Add public key to lock script util ([8dd1844](https://github.com/nervosnetwork/ckb-sdk-swift/commit/8dd1844))
* Extract and make public of TransactionSerializer/ScriptSerializer ([8c79f70](https://github.com/nervosnetwork/ckb-sdk-swift/commit/8c79f70))
* Implement Array Serializer(s) ([b8598fd](https://github.com/nervosnetwork/ckb-sdk-swift/commit/b8598fd))
* Implement ByteSerializer ([eb64ddd](https://github.com/nervosnetwork/ckb-sdk-swift/commit/eb64ddd))
* Implement DynVecSerializer ([a87a8da](https://github.com/nervosnetwork/ckb-sdk-swift/commit/a87a8da))
* Implement FixVecSerializer, refactor other serializers ([16b6186](https://github.com/nervosnetwork/ckb-sdk-swift/commit/16b6186))
* Implement StructSerializer ([6530566](https://github.com/nervosnetwork/ckb-sdk-swift/commit/6530566))
* Implement TableSerializer ([fad544e](https://github.com/nervosnetwork/ckb-sdk-swift/commit/fad544e))
* Implement transaction serialization and other type serializers ([ea0eeeb](https://github.com/nervosnetwork/ckb-sdk-swift/commit/ea0eeeb))
* Re-implement ByteSerializer ([9fecdd1](https://github.com/nervosnetwork/ckb-sdk-swift/commit/9fecdd1))
* Update Script to use Molecule serialization ([013c4b3](https://github.com/nervosnetwork/ckb-sdk-swift/commit/013c4b3))
