### PR TITLE
Refactor address generator

### DIFF
--- a/Source/Payment/LiveCellCollector.swift
+++ b/Source/Payment/LiveCellCollector.swift
@@ -31,7 +31,7 @@ final class LiveCellCollector: UnspentCellCollector {
     }
 
     convenience init(apiClient: APIClient, publicKey: Data) {
-        self.init(apiClient: apiClient, publicKeyHash: AddressGenerator().hash(for: publicKey))
+        self.init(apiClient: apiClient, publicKeyHash: AddressGenerator.hash(for: publicKey))
     }
 
     // Collect all unspent cells from genesis block to current tip.

--- a/Source/Payment/Payment.swift
+++ b/Source/Payment/Payment.swift
@@ -20,12 +20,11 @@ public final class Payment {
     public var unspentCellCollectorType: UnspentCellCollector.Type! = LiveCellCollector.self
 
     public init(from: String, to: String, amount: Capacity, fee: Capacity = 0, apiClient: APIClient) throws {
-        let addressGenerator = AddressGenerator()
-        guard let fromHash = addressGenerator.publicKeyHash(for: from) else {
+        guard let fromHash = AddressGenerator.publicKeyHash(for: from) else {
             throw Error.invalidFromAddress
         }
         fromPublicKeyHash = fromHash
-        guard let toHash = addressGenerator.publicKeyHash(for: to) else {
+        guard let toHash = AddressGenerator.publicKeyHash(for: to) else {
             throw Error.invalidToAddress
         }
         toPublicKeyHash = toHash
@@ -41,7 +40,7 @@ public final class Payment {
     }
 
     public func sign(privateKey: Data) throws -> Transaction? {
-        let pubKeyHash = AddressGenerator().hash(for: Utils.privateToPublic(privateKey))
+        let pubKeyHash = AddressGenerator.hash(for: Utils.privateToPublic(privateKey))
         guard pubKeyHash.toHexString() == fromPublicKeyHash else {
             throw Error.privateKeyAndAddressNotMatch
         }

--- a/Source/Utils/AddressGenerator.swift
+++ b/Source/Utils/AddressGenerator.swift
@@ -11,7 +11,7 @@ import Foundation
 public class AddressGenerator {
     public init() {}
 
-    func prefix(network: Network) -> String {
+    static func prefix(network: Network) -> String {
         switch network {
         case .testnet:
             return "ckt"
@@ -20,26 +20,26 @@ public class AddressGenerator {
         }
     }
 
-    public func publicKeyHash(for address: String) -> String? {
+    public static func publicKeyHash(for address: String) -> String? {
         guard let data = parse(address: address)?.data else {
             return nil
         }
         return Data(data.bytes.suffix(20)).toHexString()
     }
 
-    public func address(for publicKey: String, network: Network = .testnet) -> String {
+    public static func address(for publicKey: String, network: Network = .testnet) -> String {
         return address(for: Data(hex: publicKey), network: network)
     }
 
-    public func address(for publicKey: Data, network: Network = .testnet) -> String {
+    public static func address(for publicKey: Data, network: Network = .testnet) -> String {
         return address(publicKeyHash: hash(for: publicKey), network: network)
     }
 
-    public func address(publicKeyHash: String, network: Network = .testnet) -> String {
+    public static func address(publicKeyHash: String, network: Network = .testnet) -> String {
         return address(publicKeyHash: Data(hex: publicKeyHash), network: network)
     }
 
-    public func address(publicKeyHash: Data, network: Network = .testnet) -> String {
+    public static func address(publicKeyHash: Data, network: Network = .testnet) -> String {
         // Payload: type(01) | code hash index(00, P2PH) | pubkey blake160
         let type = Data([0x01])
         let codeHashIndex = Data([0x00])
@@ -47,11 +47,11 @@ public class AddressGenerator {
         return Bech32().encode(hrp: prefix(network: network), data: convertBits(data: payload, fromBits: 8, toBits: 5, pad: true)!)
     }
 
-    public func hash(for publicKey: Data) -> Data {
+    public static func hash(for publicKey: Data) -> Data {
         return blake160(publicKey)
     }
 
-    private func parse(address: String) -> (hrp: String, data: Data)? {
+    private static func parse(address: String) -> (hrp: String, data: Data)? {
         if let parsed = Bech32().decode(bech32: address) {
             if let data = convertBits(data: parsed.data, fromBits: 5, toBits: 8, pad: false) {
                 return (hrp: parsed.hrp, data: data)
@@ -61,13 +61,13 @@ public class AddressGenerator {
         return nil
     }
 
-    private func blake160(_ data: Data) -> Data {
+    private static func blake160(_ data: Data) -> Data {
         return Blake2b().hash(data: data)!.prefix(upTo: 20)
     }
 }
 
 extension AddressGenerator {
-    private func convertBits(data: Data, fromBits: Int, toBits: Int, pad: Bool) -> Data? {
+    private static func convertBits(data: Data, fromBits: Int, toBits: Int, pad: Bool) -> Data? {
         var ret = Data()
         var acc = 0
         var bits = 0

--- a/Source/Utils/SystemScript.swift
+++ b/Source/Utils/SystemScript.swift
@@ -38,7 +38,7 @@ public struct SystemScript {
     }
 
     public func lock(for publicKey: Data) -> Script {
-        let publicKeyHash = AddressGenerator().hash(for: publicKey).toHexString()
+        let publicKeyHash = AddressGenerator.hash(for: publicKey).toHexString()
         return lock(for: publicKeyHash)
     }
 

--- a/Source/Utils/Utils.swift
+++ b/Source/Utils/Utils.swift
@@ -22,13 +22,11 @@ public struct Utils {
     }
 
     public static func publicToAddress(_ publicKey: String, network: Network = .testnet) -> String {
-        let generator = AddressGenerator()
-        return generator.address(for: publicKey, network: network)
+        return AddressGenerator.address(for: publicKey, network: network)
     }
 
     public static func publicKeyHashToAddress(_ publicKeyHash: String, network: Network = .testnet) -> String {
-        let generator = AddressGenerator()
-        return generator.address(publicKeyHash: publicKeyHash, network: network)
+        return AddressGenerator.address(publicKeyHash: publicKeyHash, network: network)
     }
 
     public static func privateToAddress(_ privateKey: String, network: Network = .testnet) -> String {

--- a/Tests/Utils/AddressGeneratorTests.swift
+++ b/Tests/Utils/AddressGeneratorTests.swift
@@ -77,4 +77,13 @@ class AddressGeneratorTests: XCTestCase {
         )
         XCTAssertNil(AddressGenerator.publicKeyHash(for: "bbbbb"))
     }
+
+    func testValidate() {
+        XCTAssertTrue(AddressGenerator.validate("ckb1qyqp8eqad7ffy42ezmchkjyz54rhcqf8q9pqrn323p"))
+        XCTAssertTrue(AddressGenerator.validate("ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83"))
+
+        XCTAssertFalse(AddressGenerator.validate("ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu8i")) // Wrong checksum
+        XCTAssertFalse(AddressGenerator.validate("ckt1qyqrdaefa43s6m882pcj53m4gdnj4k440axqswmu83")) // None Bech32 character
+        XCTAssertFalse(AddressGenerator.validate("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7")) // None ckt/ckb addresses
+    }
 }

--- a/Tests/Utils/AddressGeneratorTests.swift
+++ b/Tests/Utils/AddressGeneratorTests.swift
@@ -9,79 +9,72 @@ import XCTest
 
 class AddressGeneratorTests: XCTestCase {
     func testPublicKeyHash() {
-        let generator = AddressGenerator()
-        let hash = generator.hash(for: Data(hex: "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01"))
+        let hash = AddressGenerator.hash(for: Data(hex: "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01"))
         XCTAssertEqual(Data(hex: "0x36c329ed630d6ce750712a477543672adab57f4c"), hash)
     }
 
     func testPubkeyToAddressTestnet() {
-        let generator = AddressGenerator()
         XCTAssertEqual(
             "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83",
-            generator.address(for: "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01")
+            AddressGenerator.address(for: "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01")
         )
         XCTAssertEqual(
             "ckt1qyqq96psh4h7rxgjl7mmpvf5e0jnz79earcsyrlxrx",
-            generator.address(for: "0x0331b3c0225388c5010e3507beb28ecf409c022ef6f358f02b139cbae082f5a2a3")
+            AddressGenerator.address(for: "0x0331b3c0225388c5010e3507beb28ecf409c022ef6f358f02b139cbae082f5a2a3")
         )
         XCTAssertEqual(
             "ckt1qyq0phsyqvgkfkzrshphsramyxyz8yew3yzsl76naf",
-            generator.address(for: "0x0360bf05c11e7b4ac8de58077554e3d777acd64bf4abb9cd947002eb98a4827bba")
+            AddressGenerator.address(for: "0x0360bf05c11e7b4ac8de58077554e3d777acd64bf4abb9cd947002eb98a4827bba")
         )
     }
 
     func testPubkeyToAddressMainnet() {
-        let generator = AddressGenerator()
         XCTAssertEqual(
             "ckb1qyqrdsefa43s6m882pcj53m4gdnj4k440axqdt9rtd",
-            generator.address(for: "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01", network: .mainnet)
+            AddressGenerator.address(for: "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01", network: .mainnet)
         )
     }
 
     func testPubkeyHashToAddressTestnet() {
-        let generator = AddressGenerator()
         XCTAssertEqual(
             "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83",
-            generator.address(publicKeyHash: "0x36c329ed630d6ce750712a477543672adab57f4c")
+            AddressGenerator.address(publicKeyHash: "0x36c329ed630d6ce750712a477543672adab57f4c")
         )
         XCTAssertEqual(
             "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83",
-            generator.address(publicKeyHash: Data(hex: "0x36c329ed630d6ce750712a477543672adab57f4c"))
+            AddressGenerator.address(publicKeyHash: Data(hex: "0x36c329ed630d6ce750712a477543672adab57f4c"))
         )
     }
 
     func testPubkeyHashToAddressMainnet() {
-        let generator = AddressGenerator()
         XCTAssertEqual(
             "ckb1qyqrdsefa43s6m882pcj53m4gdnj4k440axqdt9rtd",
-            generator.address(publicKeyHash: "0x36c329ed630d6ce750712a477543672adab57f4c", network: .mainnet)
+            AddressGenerator.address(publicKeyHash: "0x36c329ed630d6ce750712a477543672adab57f4c", network: .mainnet)
         )
         XCTAssertEqual(
             "ckb1qyqrdsefa43s6m882pcj53m4gdnj4k440axqdt9rtd",
-            generator.address(publicKeyHash: Data(hex: "0x36c329ed630d6ce750712a477543672adab57f4c"), network: .mainnet)
+            AddressGenerator.address(publicKeyHash: Data(hex: "0x36c329ed630d6ce750712a477543672adab57f4c"), network: .mainnet)
         )
     }
 
     func testPubkeyHashToAddressMainnetRFC() {
-        let generator = AddressGenerator()
         XCTAssertEqual(
             "ckb1qyqp8eqad7ffy42ezmchkjyz54rhcqf8q9pqrn323p",
-            generator.address(publicKeyHash: "0x13e41d6F9292555916f17B4882a5477C01270142", network: .mainnet)
+            AddressGenerator.address(publicKeyHash: "0x13e41d6F9292555916f17B4882a5477C01270142", network: .mainnet)
         )
         XCTAssertEqual(
             "ckb1qyqp8eqad7ffy42ezmchkjyz54rhcqf8q9pqrn323p",
-            generator.address(publicKeyHash: Data(hex: "0x13e41d6F9292555916f17B4882a5477C01270142"), network: .mainnet)
+            AddressGenerator.address(publicKeyHash: Data(hex: "0x13e41d6F9292555916f17B4882a5477C01270142"), network: .mainnet)
         )
     }
 
     func testAddressToPubkeyHash() {
         let publicKey = "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01"
-        let generator = AddressGenerator()
-        let address = generator.address(for: publicKey)
+        let address = AddressGenerator.address(for: publicKey)
         XCTAssertEqual(
-            generator.hash(for: Data(hex: publicKey)).toHexString(),
-            generator.publicKeyHash(for: address)
+            AddressGenerator.hash(for: Data(hex: publicKey)).toHexString(),
+            AddressGenerator.publicKeyHash(for: address)
         )
-        XCTAssertNil(generator.publicKeyHash(for: "bbbbb"))
+        XCTAssertNil(AddressGenerator.publicKeyHash(for: "bbbbb"))
     }
 }


### PR DESCRIPTION
* Change all func to static. No need to initialize an instance of `AddressGenerator`.
* Add `validate` func.

@shaojunda Are you aware of any other rules we should follow when validating an address?