### PR TITLE
feat: Allow live cell collector to accept a from block number param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       name: Tests with RPC
       env:
         - SKIP_RPC_TESTS=0
-        - CKB_VERSION=v0.21.0
+        - CKB_VERSION=v0.21.1
         - CKB_FILENAME=ckb_${CKB_VERSION}_x86_64-apple-darwin
       before_script:
         - mkdir ckb

--- a/CKB.podspec
+++ b/CKB.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CKB"
-  s.version      = "0.21.0"
+  s.version      = "0.21.1"
   s.summary      = "Swift SDK for Nervos CKB"
 
   s.description  = <<-DESC

--- a/CKB.xcodeproj/project.pbxproj
+++ b/CKB.xcodeproj/project.pbxproj
@@ -1144,7 +1144,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.21.0;
+				MARKETING_VERSION = 0.21.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nervos.CKB;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
@@ -1175,7 +1175,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.21.0;
+				MARKETING_VERSION = 0.21.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nervos.CKB;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;

--- a/Source/Payment/LiveCellCollector.swift
+++ b/Source/Payment/LiveCellCollector.swift
@@ -8,7 +8,7 @@ import Foundation
 
 public protocol UnspentCellCollector {
     init(apiClient: APIClient, publicKeyHash: Data)
-    func getUnspentCells(_ maxCapacity: Capacity) -> [CellOutputWithOutPoint]
+    func getUnspentCells(from blockNumber: BlockNumber, maxCapacity: Capacity) -> [CellOutputWithOutPoint]
 }
 
 /// LiveCellCollector collects live cells (unspent cells) provided a public key.
@@ -37,9 +37,9 @@ final class LiveCellCollector: UnspentCellCollector {
     // Collect all unspent cells from genesis block to current tip.
     // All types of live cells are collected.
     // Performance concern: this has to iterate over all blocks. It could be very slow.
-    func getUnspentCells(_ maxCapacity: Capacity = .max) -> [CellOutputWithOutPoint] {
-        var from = BlockNumber(0)
-        var to = BlockNumber(0)
+    func getUnspentCells(from blockNumber: BlockNumber = 0, maxCapacity: Capacity = .max) -> [CellOutputWithOutPoint] {
+        var from = blockNumber
+        var to = from
         let step = BlockNumber(100) // Max allowed is 100
         guard let tip = try? apiClient.getTipBlockNumber() else {
             return []

--- a/Source/Payment/LiveCellCollector.swift
+++ b/Source/Payment/LiveCellCollector.swift
@@ -6,9 +6,14 @@
 
 import Foundation
 
+public struct UnspentCells {
+    public let cells: [CellOutputWithOutPoint]
+    public let lastBlockNumber: BlockNumber // Last block that's scanned from
+}
+
 public protocol UnspentCellCollector {
     init(apiClient: APIClient, publicKeyHash: Data)
-    func getUnspentCells(from blockNumber: BlockNumber, maxCapacity: Capacity) -> [CellOutputWithOutPoint]
+    func getUnspentCells(from blockNumber: BlockNumber, maxCapacity: Capacity) -> UnspentCells
 }
 
 /// LiveCellCollector collects live cells (unspent cells) provided a public key.
@@ -37,12 +42,12 @@ final class LiveCellCollector: UnspentCellCollector {
     // Collect all unspent cells from genesis block to current tip.
     // All types of live cells are collected.
     // Performance concern: this has to iterate over all blocks. It could be very slow.
-    func getUnspentCells(from blockNumber: BlockNumber = 0, maxCapacity: Capacity = .max) -> [CellOutputWithOutPoint] {
+    func getUnspentCells(from blockNumber: BlockNumber = 0, maxCapacity: Capacity = .max) -> UnspentCells {
         var from = blockNumber
         var to = from
         let step = BlockNumber(100) // Max allowed is 100
         guard let tip = try? apiClient.getTipBlockNumber() else {
-            return []
+            return UnspentCells(cells: [], lastBlockNumber: 0)
         }
 
         var capacity = Capacity(0)
@@ -56,6 +61,6 @@ final class LiveCellCollector: UnspentCellCollector {
             from = to + 1
         }
 
-        return results
+        return UnspentCells(cells: results, lastBlockNumber: from)
     }
 }

--- a/Source/Payment/Payment.swift
+++ b/Source/Payment/Payment.swift
@@ -121,7 +121,7 @@ private extension Payment {
         var amountCollected = Capacity(0)
         var inputs = [CellInput]()
 
-        collecting: for cell in collector.getUnspentCells(amountToCollect) {
+        collecting: for cell in collector.getUnspentCells(from: 0, maxCapacity: amountToCollect) {
             let input = CellInput(previousOutput: cell.outPoint, since: 0)
             inputs.append(input)
             amountCollected += cell.capacity

--- a/Source/Payment/Payment.swift
+++ b/Source/Payment/Payment.swift
@@ -17,6 +17,8 @@ public final class Payment {
     private let apiClient: APIClient
 
     public var signedTx: Transaction?
+    /// Keep track of the block number around which this payment has scanned and stopped.
+    public private(set) var lastBlockNumber: BlockNumber = 0
     public var unspentCellCollectorType: UnspentCellCollector.Type! = LiveCellCollector.self
 
     public init(from: String, to: String, amount: Capacity, fee: Capacity = 0, apiClient: APIClient) throws {
@@ -121,7 +123,8 @@ private extension Payment {
         var amountCollected = Capacity(0)
         var inputs = [CellInput]()
 
-        collecting: for cell in collector.getUnspentCells(from: 0, maxCapacity: amountToCollect) {
+        let unspentCells = collector.getUnspentCells(from: 0, maxCapacity: amountToCollect)
+        collecting: for cell in unspentCells.cells {
             let input = CellInput(previousOutput: cell.outPoint, since: 0)
             inputs.append(input)
             amountCollected += cell.capacity
@@ -137,6 +140,7 @@ private extension Payment {
         if amountToCollect > amountCollected {
             return ([], 0)
         }
+        self.lastBlockNumber = unspentCells.lastBlockNumber
         return (inputs, amountCollected - amountToCollect)
     }
 

--- a/Tests/Payment/LiveCellCollectorTests.swift
+++ b/Tests/Payment/LiveCellCollectorTests.swift
@@ -12,6 +12,6 @@ class LiveCellCollectorTests: RPCTestSkippable {
         let api = APIClient(url: APIClient.defaultLocalURL)
         let collector = LiveCellCollector(apiClient: api, publicKey: Data(hex: "0x03c4b0a0307375feac6970a994bf0b1d527c094aed271a86b085861f41fbbdb736"))
         let results = collector.getUnspentCells()
-        XCTAssert(results.count >= 0)
+        XCTAssert(results.cells.count >= 0)
     }
 }

--- a/Tests/Payment/PaymentTests.swift
+++ b/Tests/Payment/PaymentTests.swift
@@ -144,7 +144,7 @@ class PaymentTests: RPCTestSkippable {
         }
 
         // Always return cells for 10,000 CKB
-        func getUnspentCells(from blockNumber: BlockNumber, maxCapacity: Capacity) -> [CellOutputWithOutPoint] {
+        func getUnspentCells(from blockNumber: BlockNumber, maxCapacity: Capacity) -> UnspentCells {
             let makeCell: (_ capacity: Capacity) -> CellOutputWithOutPoint = { [unowned self] capacity in
                 return CellOutputWithOutPoint(
                     outPoint: OutPoint(txHash: H256.zeroHash, index: 0),
@@ -153,12 +153,15 @@ class PaymentTests: RPCTestSkippable {
                     lock: Script(args: [Utils.prefixHex(self.publicKeyHash.toHexString())], codeHash: H256.zeroHash, hashType: .type)
                 )
             }
-            return [
-                makeCell(1000_00_000_000),
-                makeCell(2000_00_000_000),
-                makeCell(3000_00_000_000),
-                makeCell(4000_00_000_000)
-            ]
+            return UnspentCells(
+                cells: [
+                    makeCell(1000_00_000_000),
+                    makeCell(2000_00_000_000),
+                    makeCell(3000_00_000_000),
+                    makeCell(4000_00_000_000)
+                ],
+                lastBlockNumber: 0
+            )
         }
     }
 }

--- a/Tests/Payment/PaymentTests.swift
+++ b/Tests/Payment/PaymentTests.swift
@@ -144,7 +144,7 @@ class PaymentTests: RPCTestSkippable {
         }
 
         // Always return cells for 10,000 CKB
-        func getUnspentCells(_ maxCapacity: Capacity) -> [CellOutputWithOutPoint] {
+        func getUnspentCells(from blockNumber: BlockNumber, maxCapacity: Capacity) -> [CellOutputWithOutPoint] {
             let makeCell: (_ capacity: Capacity) -> CellOutputWithOutPoint = { [unowned self] capacity in
                 return CellOutputWithOutPoint(
                     outPoint: OutPoint(txHash: H256.zeroHash, index: 0),

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
       sdk: 'macosx10.14'
       configuration: 'Debug'
       skip_rpc_tests: 0
-      ckb_version: 'v0.21.0'
+      ckb_version: 'v0.21.1'
     steps:
       - task: CocoaPods@0
         displayName: 'pod install using the CocoaPods task with defaults'


### PR DESCRIPTION
Allow collector to only scan blocks starting from a specified number.

Client could persist last used block number and only collect from that block for future payments.