### PR TITLE
[ᚬmaster] Rc/v0.24.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,7 @@ disabled_rules:
   - force_try
   - identifier_name
   - todo
+  - large_tuple
 
 included:
   - Source

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       name: Tests with RPC
       env:
         - SKIP_RPC_TESTS=0
-        - CKB_VERSION=v0.24.0-rc1
+        - CKB_VERSION=v0.24.0-rc2
         - CKB_FILENAME=ckb_${CKB_VERSION}_x86_64-apple-darwin
       before_script:
         - mkdir ckb

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       name: Tests with RPC
       env:
         - SKIP_RPC_TESTS=0
-        - CKB_VERSION=v0.23.0
+        - CKB_VERSION=v0.24.0-rc1
         - CKB_FILENAME=ckb_${CKB_VERSION}_x86_64-apple-darwin
       before_script:
         - mkdir ckb

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       name: Tests with RPC
       env:
         - SKIP_RPC_TESTS=0
-        - CKB_VERSION=v0.24.0-rc2
+        - CKB_VERSION=v0.24.0
         - CKB_FILENAME=ckb_${CKB_VERSION}_x86_64-apple-darwin
       before_script:
         - mkdir ckb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 
 ### Features
 
+* Calculate transaction fee ([73dae6e](https://github.com/nervosnetwork/ckb-sdk-swift/commit/73dae6e))
 * Implement estimate_fee_rate RPC ([9e43807](https://github.com/nervosnetwork/ckb-sdk-swift/commit/9e43807))
+* Implement tx size calculation ([b4bac55](https://github.com/nervosnetwork/ckb-sdk-swift/commit/b4bac55))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [v0.24.0](https://github.com/nervosnetwork/ckb-sdk-swift/compare/v0.23.1...v0.24.0) (2019-11-02)
+
+
+### Features
+
+* Implement estimate_fee_rate RPC ([9e43807](https://github.com/nervosnetwork/ckb-sdk-swift/commit/9e43807))
+
+
+
 # [v0.23.1](https://github.com/nervosnetwork/ckb-sdk-swift/compare/v0.23.0...v0.23.1) (2019-10-19)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Calculate transaction fee ([73dae6e](https://github.com/nervosnetwork/ckb-sdk-swift/commit/73dae6e))
 * Implement estimate_fee_rate RPC ([9e43807](https://github.com/nervosnetwork/ckb-sdk-swift/commit/9e43807))
 * Implement tx size calculation ([b4bac55](https://github.com/nervosnetwork/ckb-sdk-swift/commit/b4bac55))
+* Implement WitnessArgs and its serializer ([f052a04](https://github.com/nervosnetwork/ckb-sdk-swift/commit/f052a04))
+* Let WitnessArgs support both parsed witness and raw data ([15dfe74](https://github.com/nervosnetwork/ckb-sdk-swift/commit/15dfe74))
+* Update tx signing ([499978e](https://github.com/nervosnetwork/ckb-sdk-swift/commit/499978e))
 
 
 

--- a/CKB.podspec
+++ b/CKB.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CKB"
-  s.version      = "0.23.1"
+  s.version      = "0.24.0"
   s.summary      = "Swift SDK for Nervos CKB"
 
   s.description  = <<-DESC

--- a/CKB.xcodeproj/project.pbxproj
+++ b/CKB.xcodeproj/project.pbxproj
@@ -1136,7 +1136,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.23.1;
+				MARKETING_VERSION = 0.24.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nervos.CKB;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
@@ -1167,7 +1167,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.23.1;
+				MARKETING_VERSION = 0.24.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nervos.CKB;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;

--- a/CKB.xcodeproj/project.pbxproj
+++ b/CKB.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A00059C23690F980069AC80 /* FeeRateResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A00059B23690F980069AC80 /* FeeRateResult.swift */; };
+		1A00059F236910980069AC80 /* estimateFeeRate.json in Resources */ = {isa = PBXBuildFile; fileRef = 1A00059D236910630069AC80 /* estimateFeeRate.json */; };
 		1A014D5E232A707E00CBBBA7 /* liveCell.json in Resources */ = {isa = PBXBuildFile; fileRef = 1A014D5D232A707E00CBBBA7 /* liveCell.json */; };
 		1A11347E2228D14300840EE8 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A11347D2228D14300840EE8 /* Node.swift */; };
 		1A199DEB22BA3225000C0C34 /* LockHashIndexState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A199DEA22BA3225000C0C34 /* LockHashIndexState.swift */; };
@@ -137,6 +139,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1A00059B23690F980069AC80 /* FeeRateResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeRateResult.swift; sourceTree = "<group>"; };
+		1A00059D236910630069AC80 /* estimateFeeRate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = estimateFeeRate.json; sourceTree = "<group>"; };
 		1A014D5D232A707E00CBBBA7 /* liveCell.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = liveCell.json; sourceTree = "<group>"; };
 		1A11347D2228D14300840EE8 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		1A199DE222BA2781000C0C34 /* getTransactionsByLockHash.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = getTransactionsByLockHash.json; sourceTree = "<group>"; };
@@ -358,6 +362,7 @@
 				1AA9B6872283D10E00C116B2 /* blockchainInfo.json */,
 				1AA9B6892283D15600C116B2 /* peersState.json */,
 				1A2188752288FC7B00F613CF /* dryRunTransaction.json */,
+				1A00059D236910630069AC80 /* estimateFeeRate.json */,
 				1A2188772288FEC800F613CF /* computeTransactionHash.json */,
 				1AD01E08230F694B0005199E /* computeScriptHash.json */,
 				1AB7517122BA273600AC9F63 /* getLiveCellsByLockHash.json */,
@@ -456,6 +461,7 @@
 				1AB7516D22BA0F7100AC9F63 /* AlertMessage.swift */,
 				1AA9B6852283CE4500C116B2 /* PeerState.swift */,
 				1A2188732288FC1700F613CF /* DryRunResult.swift */,
+				1A00059B23690F980069AC80 /* FeeRateResult.swift */,
 				1A199DEA22BA3225000C0C34 /* LockHashIndexState.swift */,
 				1AA3B83D22EEBAFA00027520 /* BannedAddress.swift */,
 				1AA3B84122EEBB4800027520 /* BlockReward.swift */,
@@ -717,6 +723,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1A00059F236910980069AC80 /* estimateFeeRate.json in Resources */,
 				1A2D6B2E22A35C5A00724E66 /* sendTransactionEmpty.json in Resources */,
 				1A2D6B3222A35C5A00724E66 /* txPoolInfo.json in Resources */,
 				1A199DEF22BA352D000C0C34 /* deindexLockHash.json in Resources */,
@@ -884,6 +891,7 @@
 				1A414A8821C36FCF00B28C09 /* Header.swift in Sources */,
 				1AC180912264634E00D243D9 /* Bech32.swift in Sources */,
 				1AD96320228D24FB00684FBB /* SystemScript.swift in Sources */,
+				1A00059C23690F980069AC80 /* FeeRateResult.swift in Sources */,
 				1A11347E2228D14300840EE8 /* Node.swift in Sources */,
 				1A414A7B21C22A9300B28C09 /* APIClient.swift in Sources */,
 				1A703C2B231FAF1000EDF2C6 /* FixVecSerializer.swift in Sources */,

--- a/CKB.xcodeproj/project.pbxproj
+++ b/CKB.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		1A00059F236910980069AC80 /* estimateFeeRate.json in Resources */ = {isa = PBXBuildFile; fileRef = 1A00059D236910630069AC80 /* estimateFeeRate.json */; };
 		1A014D5E232A707E00CBBBA7 /* liveCell.json in Resources */ = {isa = PBXBuildFile; fileRef = 1A014D5D232A707E00CBBBA7 /* liveCell.json */; };
 		1A11347E2228D14300840EE8 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A11347D2228D14300840EE8 /* Node.swift */; };
+		1A136C46236BA87D004575FC /* WitnessArgs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A136C45236BA87D004575FC /* WitnessArgs.swift */; };
+		1A136C48236BAA5A004575FC /* WitnessArgsSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A136C47236BAA5A004575FC /* WitnessArgsSerializer.swift */; };
+		1A136C4A236BBF2B004575FC /* WitnessArgsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A136C49236BBF2B004575FC /* WitnessArgsTests.swift */; };
 		1A199DEB22BA3225000C0C34 /* LockHashIndexState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A199DEA22BA3225000C0C34 /* LockHashIndexState.swift */; };
 		1A199DEC22BA3526000C0C34 /* getLiveCellsByLockHash.json in Resources */ = {isa = PBXBuildFile; fileRef = 1AB7517122BA273600AC9F63 /* getLiveCellsByLockHash.json */; };
 		1A199DED22BA352D000C0C34 /* getTransactionsByLockHash.json in Resources */ = {isa = PBXBuildFile; fileRef = 1A199DE222BA2781000C0C34 /* getTransactionsByLockHash.json */; };
@@ -143,6 +146,9 @@
 		1A00059D236910630069AC80 /* estimateFeeRate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = estimateFeeRate.json; sourceTree = "<group>"; };
 		1A014D5D232A707E00CBBBA7 /* liveCell.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = liveCell.json; sourceTree = "<group>"; };
 		1A11347D2228D14300840EE8 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		1A136C45236BA87D004575FC /* WitnessArgs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WitnessArgs.swift; sourceTree = "<group>"; };
+		1A136C47236BAA5A004575FC /* WitnessArgsSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WitnessArgsSerializer.swift; sourceTree = "<group>"; };
+		1A136C49236BBF2B004575FC /* WitnessArgsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WitnessArgsTests.swift; sourceTree = "<group>"; };
 		1A199DE222BA2781000C0C34 /* getTransactionsByLockHash.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = getTransactionsByLockHash.json; sourceTree = "<group>"; };
 		1A199DE422BA2809000C0C34 /* indexLockHash.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = indexLockHash.json; sourceTree = "<group>"; };
 		1A199DE622BA281D000C0C34 /* deindexLockHash.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = deindexLockHash.json; sourceTree = "<group>"; };
@@ -327,6 +333,7 @@
 				1A36096A2322853F000E67EE /* CellOutputSerializer.swift */,
 				1A36096C23228675000E67EE /* CellDepSerializer.swift */,
 				1A2F5FB823223D9F000051CC /* ScriptSerializer.swift */,
+				1A136C47236BAA5A004575FC /* WitnessArgsSerializer.swift */,
 				1A2F5FBA23223DF1000051CC /* TransactionSerializer.swift */,
 			);
 			path = TypeSerializers;
@@ -454,6 +461,7 @@
 				1A414A8721C36FCF00B28C09 /* Header.swift */,
 				1A414A8921C36FE900B28C09 /* Block.swift */,
 				1A2CDAE0228171180024CA71 /* Epoch.swift */,
+				1A136C45236BA87D004575FC /* WitnessArgs.swift */,
 				1A414A8B21C3714E00B28C09 /* Transaction.swift */,
 				1A11347D2228D14300840EE8 /* Node.swift */,
 				1A4AEBDA2282EB0100F0D576 /* TxPoolInfo.swift */,
@@ -510,6 +518,7 @@
 		1A5BCBB4228C6B9200157426 /* Signers */ = {
 			isa = PBXGroup;
 			children = (
+				1A136C49236BBF2B004575FC /* WitnessArgsTests.swift */,
 				1A5BCBB5228C6BB400157426 /* TransactionSignTests.swift */,
 			);
 			path = Signers;
@@ -876,6 +885,7 @@
 				1A2D6B3722A35C5A00724E66 /* APIClientTests.swift in Sources */,
 				1A2F5FB72321F1FE000051CC /* SerializerTests.swift in Sources */,
 				1A2D6B2622A35C4F00724E66 /* SystemScriptTests.swift in Sources */,
+				1A136C4A236BBF2B004575FC /* WitnessArgsTests.swift in Sources */,
 				1A703C33231FAF6300EDF2C6 /* TableSerializerTests.swift in Sources */,
 				1A85455123212A5B00B26DC0 /* ByteSerializerTests.swift in Sources */,
 				1A36097423228B22000E67EE /* ScriptSerializerTests.swift in Sources */,
@@ -897,6 +907,7 @@
 				1A703C2B231FAF1000EDF2C6 /* FixVecSerializer.swift in Sources */,
 				1AB7516E22BA0F7100AC9F63 /* AlertMessage.swift in Sources */,
 				1A6796B5232F0BB4001E9E3D /* LiveCellCollector.swift in Sources */,
+				1A136C48236BAA5A004575FC /* WitnessArgsSerializer.swift in Sources */,
 				1AB45ED7222AA558009B395B /* Secp256k1.swift in Sources */,
 				1A5BCBB3228C571200157426 /* Transaction+Sign.swift in Sources */,
 				D5B02A91230A8030006B4189 /* CellDep.swift in Sources */,
@@ -935,6 +946,7 @@
 				1A703C47232085CC00EDF2C6 /* Serializer.swift in Sources */,
 				1A414A8A21C36FE900B28C09 /* Block.swift in Sources */,
 				1A414A9421C3789000B28C09 /* Primitives.swift in Sources */,
+				1A136C46236BA87D004575FC /* WitnessArgs.swift in Sources */,
 				1A703C41231FB19A00EDF2C6 /* UnionSerializer.swift in Sources */,
 				1A2F5FB923223D9F000051CC /* ScriptSerializer.swift in Sources */,
 				1A414A8321C334EB00B28C09 /* APIRequest.swift in Sources */,

--- a/Source/API/APIClient+Experiment.swift
+++ b/Source/API/APIClient+Experiment.swift
@@ -18,4 +18,8 @@ public extension APIClient {
     func dryRunTransaction(transaction: Transaction) throws -> DryRunResult {
         return try load(APIRequest<DryRunResult>(method: "dry_run_transaction", params: [transaction.param]))
     }
+
+    func estimateFeeRate(expectedConfirmBlocks: BlockNumber) throws -> FeeRateResult {
+        return try load(APIRequest<FeeRateResult>(method: "estimate_fee_rate", params: [expectedConfirmBlocks.hexString]))
+    }
 }

--- a/Source/Payment/Payment.swift
+++ b/Source/Payment/Payment.swift
@@ -114,7 +114,12 @@ private extension Payment {
             inputs: inputs,
             outputs: outputs,
             outputsData: outputs.map { _ in "0x" },
-            witnesses: inputs.map { _ in "0x" }
+            unsignedWitnesses: inputs.enumerated().map({ (index, _) in
+                if index == 0 {
+                    return WitnessArgs.emptyLock
+                }
+                return .data("0x")
+            })
         )
     }
 

--- a/Source/Serialization/BaseSerializers/ByteSerializer.swift
+++ b/Source/Serialization/BaseSerializers/ByteSerializer.swift
@@ -29,3 +29,5 @@ struct ByteSerializer: ObjectSerializer {
         self.init(value: byte)
     }
 }
+
+typealias BytesSerializer = FixVecSerializer<Byte, ByteSerializer>

--- a/Source/Serialization/BaseSerializers/OptionSerializer.swift
+++ b/Source/Serialization/BaseSerializers/OptionSerializer.swift
@@ -31,3 +31,13 @@ struct OptionSerializer<T, TSerializer: Serializer>: ObjectSerializer {
         self.init(value: value, serializer: nil)
     }
 }
+
+struct EmptySerializer: Serializer {
+    var header: [Byte] {
+        return []
+    }
+
+    var body: [Byte] {
+        return []
+    }
+}

--- a/Source/Serialization/Serializer.swift
+++ b/Source/Serialization/Serializer.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 // [CKB Serialization RFC](https://github.com/yangby-cryptape/rfcs/blob/pr/serialization/rfcs/0008-serialization/0008-serialization.md)
-// [CKB Types serialization schema](https://github.com/nervosnetwork/ckb/blob/develop/util/types/schemas/ckb.mol)
+// [CKB Types serialization schema](https://github.com/nervosnetwork/ckb/blob/develop/util/types/schemas/blockchain.mol)
 
 // Primitive Type
 typealias Byte = UInt8

--- a/Source/Serialization/TypeSerializers/ScriptSerializer.swift
+++ b/Source/Serialization/TypeSerializers/ScriptSerializer.swift
@@ -19,7 +19,7 @@ public final class ScriptSerializer: TableSerializer<Script> {
             fieldSerializers: [
                 Byte32Serializer(value: value.codeHash)!,
                 ByteSerializer(value: value.hashType.byte),
-                FixVecSerializer<Byte, ByteSerializer>(value: Data(hex: value.args).bytes)
+                BytesSerializer(value: Data(hex: value.args).bytes)
             ]
         )
     }

--- a/Source/Serialization/TypeSerializers/TransactionSerializer.swift
+++ b/Source/Serialization/TypeSerializers/TransactionSerializer.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
- /// https://github.com/nervosnetwork/ckb/blob/develop/util/types/schemas/ckb.mol#L69
+/// https://github.com/nervosnetwork/ckb/blob/develop/util/types/schemas/blockchain.mol#L55-L67
 public final class TransactionSerializer: TableSerializer<Transaction> {
     public required init(value: Transaction) {
         let hexStringsToArrayOfBytes: ([HexString]) -> [[Byte]] = { strings in
@@ -35,5 +35,43 @@ public extension Transaction {
     func computeHash() -> H256 {
         let serialized = serialize()
         return Blake2b().hash(bytes: serialized)
+    }
+}
+
+// - MARK: Size & Fee
+
+final class TransactionPlusWitnessesSerializer: TableSerializer<Transaction> {
+    required init(value: Transaction) {
+        let hexStringsToArrayOfBytes: ([HexString]) -> [[Byte]] = { strings in
+            return strings.map { Data(hex: $0).bytes }
+        }
+        super.init(
+            value: value,
+            fieldSerializers: [
+                TransactionSerializer(value: value),
+                DynVecSerializer<[Byte], FixVecSerializer<Byte, ByteSerializer>>(value: hexStringsToArrayOfBytes(value.witnesses))
+            ]
+        )
+    }
+}
+
+extension Transaction {
+    var serializedSizeInBlock: Int {
+        let serializer = TransactionPlusWitnessesSerializer(value: self)
+        let serializedTxOffsetBytesize = 4 // 4 bytes for the tx offset cost with molecule array (transactions)
+        return serializer.serialize().count + serializedTxOffsetBytesize
+    }
+
+    public func fee(rate: UInt64) -> Capacity {
+        return Transaction.fee(for: serializedSizeInBlock, with: rate)
+    }
+
+    /// Calulate fee based on transaction size and fee rate.
+    /// - Parameter txSize: Bytesize of the serialized tx in a block
+    /// - Parameter rate: Fee rate, shannons for 1KB
+    public static func fee(for txSize: Int, with rate: UInt64) -> Capacity {
+        let base = UInt64(txSize) * rate
+        let result = base / 1000
+        return base % 1000 == 0 ? result : result + 1
     }
 }

--- a/Source/Serialization/TypeSerializers/TransactionSerializer.swift
+++ b/Source/Serialization/TypeSerializers/TransactionSerializer.swift
@@ -20,7 +20,7 @@ public final class TransactionSerializer: TableSerializer<Transaction> {
                 FixVecSerializer<[Byte], Byte32Serializer>(value: hexStringsToArrayOfBytes(value.headerDeps)),
                 FixVecSerializer<CellInput, CellInputSerializer>(value: value.inputs),
                 DynVecSerializer<CellOutput, CellOutputSerializer>(value: value.outputs),
-                DynVecSerializer<[Byte], FixVecSerializer<Byte, ByteSerializer>>(value: hexStringsToArrayOfBytes(value.outputsData))
+                DynVecSerializer<[Byte], BytesSerializer>(value: hexStringsToArrayOfBytes(value.outputsData))
             ]
         )
     }
@@ -42,14 +42,18 @@ public extension Transaction {
 
 final class TransactionPlusWitnessesSerializer: TableSerializer<Transaction> {
     required init(value: Transaction) {
-        let hexStringsToArrayOfBytes: ([HexString]) -> [[Byte]] = { strings in
-            return strings.map { Data(hex: $0).bytes }
+        let witnesses: [[Byte]]
+        if value.witnesses.isEmpty {
+            witnesses = value.serializeWitnessArgs()
+        } else {
+            witnesses = value.witnesses.map { Data(hex: $0).bytes }
         }
+
         super.init(
             value: value,
             fieldSerializers: [
                 TransactionSerializer(value: value),
-                DynVecSerializer<[Byte], FixVecSerializer<Byte, ByteSerializer>>(value: hexStringsToArrayOfBytes(value.witnesses))
+                DynVecSerializer<[Byte], BytesSerializer>(value: witnesses)
             ]
         )
     }
@@ -64,6 +68,10 @@ extension Transaction {
 
     public func fee(rate: UInt64) -> Capacity {
         return Transaction.fee(for: serializedSizeInBlock, with: rate)
+    }
+
+    func serializeWitnessArgs() -> [[Byte]] {
+        return unsignedWitnesses.map { $0.serialize() }
     }
 
     /// Calulate fee based on transaction size and fee rate.

--- a/Source/Serialization/TypeSerializers/WitnessArgsSerializer.swift
+++ b/Source/Serialization/TypeSerializers/WitnessArgsSerializer.swift
@@ -1,0 +1,31 @@
+//
+//  WitnessArgsSerializer.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+public extension WitnessArgs {
+    func serialize() -> [UInt8] {
+        switch self {
+        case .data(let hex):
+            return Data(hex: hex).bytes
+        case .parsed(let lock, let inputType, let outputType):
+            let serializer: ([Byte]) -> Serializer = { value in
+                if value.isEmpty {
+                    return EmptySerializer()
+                }
+                return BytesSerializer(value: value)
+            }
+            return TableSerializer<WitnessArgs>(
+                value: self,
+                fieldSerializers: [
+                    serializer(Data(hex: lock).bytes),
+                    serializer(Data(hex: inputType).bytes),
+                    serializer(Data(hex: outputType).bytes)
+                ]
+            ).serialize()
+        }
+    }
+}

--- a/Source/Signers/Transaction+Sign.swift
+++ b/Source/Signers/Transaction+Sign.swift
@@ -7,22 +7,40 @@
 import Foundation
 
 public extension Transaction {
+    /// Sign a transaction's witnesses data with private key.
+    /// Note this doesn't support multiple input groups yet.
+    /// - Parameter tx: The transaction to sign. It should include collected inputs and unsigned witnesses.
+    /// - Parameter privateKey: The private key to sign the transaction.
+    ///
+    /// - Returns: Signed transaction.
     static func sign(tx: Transaction, with privateKey: Data) throws -> Transaction {
-        if tx.witnesses.count < tx.inputs.count {
+        guard let firstWitness = tx.unsignedWitnesses.first, case let .parsed(_, inputType, outputType) = firstWitness else {
             throw Error.invalidNumberOfWitnesses
         }
 
         let txHash: H256 = tx.computeHash()
+        let emptyWitness = WitnessArgs.parsed(WitnessArgs.emptyLockHash, inputType, outputType)
+        let emptiedWitnessData = Data(emptyWitness.serialize())
+        var message = Data(hex: txHash)
+        message += Data(UInt64Serializer(value: UInt64(emptiedWitnessData.count)).serialize())
+        message += emptiedWitnessData
 
-        let signedWitnesses = try tx.witnesses.map { witness -> HexString in
-            let message: Data = [txHash, witness].map { Data(hex: $0) }.reduce(Data(), +)
-            guard let messageHash = Blake2b().hash(data: message) else {
-                throw Error.failToHashWitnessesData
-            }
-            guard let signature = Secp256k1.signRecoverable(privateKey: privateKey, data: messageHash) else {
-                throw Error.failToSignWitnessesData
-            }
-            return Utils.prefixHex(signature.toHexString()) + Utils.removeHexPrefix(witness)
+        tx.unsignedWitnesses.dropFirst().forEach { (witnessArg) in
+            let witnessData = Data(witnessArg.serialize())
+            message += Data(UInt64Serializer(value: UInt64(witnessData.count)).serialize())
+            message += witnessData
+        }
+
+        guard let messageHash = Blake2b().hash(data: message) else {
+            throw Error.failToHashWitnessesData
+        }
+        guard let signature = Secp256k1.signRecoverable(privateKey: privateKey, data: messageHash) else {
+            throw Error.failToSignWitnessesData
+        }
+
+        let witnesses: [HexString] = tx.unsignedWitnesses.enumerated().map { (index, witnessArgs) in
+            let args = index == 0 ? .parsed(Utils.prefixHex(signature.toHexString()), inputType, outputType) : witnessArgs
+            return Utils.prefixHex(args.serialize().toHexString())
         }
 
         return Transaction(
@@ -32,7 +50,7 @@ public extension Transaction {
             inputs: tx.inputs,
             outputs: tx.outputs,
             outputsData: tx.outputsData,
-            witnesses: signedWitnesses,
+            witnesses: witnesses,
             hash: txHash
         )
     }

--- a/Source/Types/FeeRateResult.swift
+++ b/Source/Types/FeeRateResult.swift
@@ -1,0 +1,20 @@
+//
+//  FeeRateResult.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+public struct FeeRateResult: Codable {
+    public let feeRate: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case feeRate = "fee_rate"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        feeRate = UInt64(hexString: try container.decode(String.self, forKey: .feeRate))!
+    }
+}

--- a/Source/Types/Transaction.swift
+++ b/Source/Types/Transaction.swift
@@ -13,7 +13,8 @@ public struct Transaction: Codable, Param {
     public let inputs: [CellInput]
     public let outputs: [CellOutput]
     public let outputsData: [HexString]
-    public let witnesses: [HexString]
+    public let witnesses: [HexString] // Serialized and signed witnesses
+    public let unsignedWitnesses: [WitnessArgs] // These don't parse from/to RPC object
     public let hash: H256
 
     public init(
@@ -24,6 +25,7 @@ public struct Transaction: Codable, Param {
         outputs: [CellOutput] = [],
         outputsData: [HexString] = [],
         witnesses: [HexString] = [],
+        unsignedWitnesses: [WitnessArgs] = [],
         hash: H256 = ""
     ) {
         self.version = version
@@ -33,6 +35,7 @@ public struct Transaction: Codable, Param {
         self.outputs = outputs
         self.outputsData = outputsData
         self.witnesses = witnesses
+        self.unsignedWitnesses = unsignedWitnesses
         self.hash = hash
     }
 
@@ -56,6 +59,7 @@ public struct Transaction: Codable, Param {
         outputs = try container.decode([CellOutput].self, forKey: .outputs)
         outputsData = try container.decode([HexString].self, forKey: .outputsData)
         witnesses = try container.decode([HexString].self, forKey: .witnesses)
+        unsignedWitnesses = []
         hash = try container.decode(H256.self, forKey: .hash)
     }
 

--- a/Source/Types/WitnessArgs.swift
+++ b/Source/Types/WitnessArgs.swift
@@ -1,0 +1,16 @@
+//
+//  WitnessArgs.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import Foundation
+
+public enum WitnessArgs {
+    case data(String) // Raw data as hex string
+    case parsed(String, String, String) // lock, inputType, outputType
+
+    public static let emptyLockHash = [String](repeating: "00", count: 65).joined()
+
+    public static let emptyLock: WitnessArgs = .parsed(Utils.prefixHex(emptyLockHash), "0x", "0x")
+}

--- a/Tests/API/APIClientTests.swift
+++ b/Tests/API/APIClientTests.swift
@@ -197,6 +197,13 @@ class APIClientTests: RPCTestSkippable {
         XCTAssertNotNil(result)
     }
 
+    func testEstimateFeeRate() throws {
+        let result = try? client.estimateFeeRate(expectedConfirmBlocks: 5)
+        if let result = result {
+            XCTAssert(result.feeRate >= 0)
+        }
+    }
+
     func testIndexLockHash() throws {
         let lockHash = "0x9a9a6bdbc38d4905eace1822f85237e3a1e238bb3f277aa7b7c8903441123510"
         var result = try client.indexLockHash(lockHash: lockHash, indexFrom: 0)

--- a/Tests/API/APIMockingTests.swift
+++ b/Tests/API/APIMockingTests.swift
@@ -160,6 +160,12 @@ class APIMockingTests: XCTestCase {
         XCTAssertNotNil(result)
     }
 
+    func testEstimateFeeRate() throws {
+        let result = try? getClient(json: "estimateFeeRate").estimateFeeRate(expectedConfirmBlocks: 5)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.feeRate >= 0)
+    }
+
     func testIndexLockHash() throws {
         let lockHash = "0xd8753dd87c7dd293d9b64d4ca20d77bb8e5f2d92bf08234b026e2d8b1b00e7e9"
         let result = try getClient(json: "indexLockHash").indexLockHash(lockHash: lockHash, indexFrom: 1024)

--- a/Tests/API/RPC Fixtures/estimateFeeRate.json
+++ b/Tests/API/RPC Fixtures/estimateFeeRate.json
@@ -1,0 +1,7 @@
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": {
+        "fee_rate": "0x7d0"
+    }
+}

--- a/Tests/Serialization/BaseSerializers/DynVecSerializerTests.swift
+++ b/Tests/Serialization/BaseSerializers/DynVecSerializerTests.swift
@@ -8,7 +8,6 @@ import XCTest
 @testable import CKB
 
 class DynVecSerializerTests: XCTestCase {
-    typealias BytesSerializer = FixVecSerializer<Byte, ByteSerializer>
     typealias BytesVecSerializer = DynVecSerializer<[Byte], BytesSerializer>
 
     func testEmptyBytesVector() {

--- a/Tests/Serialization/TypeSerializers/TransactionSerializerTests.swift
+++ b/Tests/Serialization/TypeSerializers/TransactionSerializerTests.swift
@@ -69,4 +69,62 @@ class TransactionSerializerTests: XCTestCase {
         )
         XCTAssertEqual(tx.computeHash(), "0xe37f68d4d81e0f790ca98c5abbd763764f826170867a0b96137f68df908e5641")
     }
+
+    func testSerializedSizeInBlock() {
+        let tx = Transaction(
+            cellDeps: [
+                CellDep(outPoint: OutPoint(txHash: "0xc12386705b5cbb312b693874f3edf45c43a274482e27b8df0fd80c8d3f5feb8b", index: 0), depType: .depGroup),
+                CellDep(outPoint: OutPoint(txHash: "0x0fb4945d52baf91e0dee2a686cdd9d84cad95b566a1d7409b970ee0a0f364f60", index: 2), depType: .depGroup)
+            ],
+            headerDeps: [],
+            inputs: [
+                CellInput(previousOutput: OutPoint(txHash: "0x31f695263423a4b05045dd25ce6692bb55d7bba2965d8be16b036e138e72cc65", index: 1), since: 0)
+            ],
+            outputs: [
+                CellOutput(
+                    capacity: 100_000_000_000,
+                    lock: Script(args: "0x59a27ef3ba84f061517d13f42cf44ed020610061", codeHash: "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88", hashType: .type),
+                    type: Script(args: "0x", codeHash: "0xece45e0979030e2f8909f76258631c42333b1e906fd9701ec3600a464a90b8f6", hashType: .data)
+                ),
+                CellOutput(capacity: 98_824_000_000_000, lock: Script(args: "0x59a27ef3ba84f061517d13f42cf44ed020610061", codeHash: "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88", hashType: .type)),
+            ],
+            outputsData: ["0x1234", "0x"],
+            witnesses: [
+                "0x82df73581bcd08cb9aa270128d15e79996229ce8ea9e4f985b49fbf36762c5c37936caf3ea3784ee326f60b8992924fcf496f9503c907982525a3436f01ab32900",
+            ]
+        )
+        XCTAssertEqual(tx.serializedSizeInBlock, 536)
+    }
+
+    func testFeeForSizeAndRate() {
+        XCTAssertEqual(932, Transaction.fee(for: 1035, with: 900))
+        XCTAssertEqual(1035, Transaction.fee(for: 1035, with: 1000))
+        XCTAssertEqual(1041, Transaction.fee(for: 1038, with: 1002))
+    }
+
+    func testTransactionFee() {
+        let tx = Transaction(
+            cellDeps: [
+                CellDep(outPoint: OutPoint(txHash: "0xc12386705b5cbb312b693874f3edf45c43a274482e27b8df0fd80c8d3f5feb8b", index: 0), depType: .depGroup),
+                CellDep(outPoint: OutPoint(txHash: "0x0fb4945d52baf91e0dee2a686cdd9d84cad95b566a1d7409b970ee0a0f364f60", index: 2), depType: .depGroup)
+            ],
+            headerDeps: [],
+            inputs: [
+                CellInput(previousOutput: OutPoint(txHash: "0x31f695263423a4b05045dd25ce6692bb55d7bba2965d8be16b036e138e72cc65", index: 1), since: 0)
+            ],
+            outputs: [
+                CellOutput(
+                    capacity: 100_000_000_000,
+                    lock: Script(args: "0x59a27ef3ba84f061517d13f42cf44ed020610061", codeHash: "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88", hashType: .type),
+                    type: Script(args: "0x", codeHash: "0xece45e0979030e2f8909f76258631c42333b1e906fd9701ec3600a464a90b8f6", hashType: .data)
+                ),
+                CellOutput(capacity: 98_824_000_000_000, lock: Script(args: "0x59a27ef3ba84f061517d13f42cf44ed020610061", codeHash: "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88", hashType: .type)),
+            ],
+            outputsData: ["0x1234", "0x"],
+            witnesses: [
+                "0x82df73581bcd08cb9aa270128d15e79996229ce8ea9e4f985b49fbf36762c5c37936caf3ea3784ee326f60b8992924fcf496f9503c907982525a3436f01ab32900",
+            ]
+        )
+        XCTAssertEqual(536, tx.fee(rate: 1000))
+    }
 }

--- a/Tests/Signers/TransactionSignTests.swift
+++ b/Tests/Signers/TransactionSignTests.swift
@@ -23,12 +23,12 @@ class TransactionSignTests: XCTestCase {
             outputs: [
                 CellOutput(
                     capacity: 100000000000,
-                    lock: Script(args: "0xe2193df51d78411601796b35b17b4f8f2cd85bd0", codeHash: "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08"),
+                    lock: Script(args: "0xe2193df51d78411601796b35b17b4f8f2cd85bd0", codeHash: "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08", hashType: .data),
                     type: nil
                 ),
                 CellOutput(
                     capacity: 4900000000000,
-                    lock: Script(args: "0x36c329ed630d6ce750712a477543672adab57f4c", codeHash: "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08"),
+                    lock: Script(args: "0x36c329ed630d6ce750712a477543672adab57f4c", codeHash: "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08", hashType: .data),
                     type: nil
                 )
             ],
@@ -36,17 +36,16 @@ class TransactionSignTests: XCTestCase {
                 "0x",
                 "0x"
             ],
-            witnesses: [
-                "0x"
+            unsignedWitnesses: [
+                WitnessArgs.emptyLock
             ]
         )
         let privateKey = Data(hex: "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3")
         let signed = try Transaction.sign(tx: tx, with: privateKey)
-        XCTAssertEqual(signed.witnesses.count, tx.inputs.count)
         XCTAssertEqual(
             signed.witnesses,
             [
-                "0x15edb4da91bd5beebf0aee82a9daa4d590ecdfc0895c6b010638573b2d1d502c50373e7d540e74eb8e3a3bd1dbd20c372c492fc7242592c8a04763be029325a900"
+                "0x55000000100000005500000055000000410000007a360306c20f1f0081d27feff5c59fb9b4307b25876543848010614fb78ea21d165f48f67ae3357eeafbad2033b1e53cd737d4e670de60e1081d514b1e05cf5100"
             ]
         )
     }
@@ -70,28 +69,88 @@ class TransactionSignTests: XCTestCase {
             outputs: [
                 CellOutput(
                     capacity: 10000009045634,
-                    lock: Script(args: "0x36c329ed630d6ce750712a477543672adab57f4c", codeHash: "0xf1951123466e4479842387a66fabfd6b65fc87fd84ae8e6cd3053edb27fff2fd"),
+                    lock: Script(args: "0x36c329ed630d6ce750712a477543672adab57f4c", codeHash: "0xf1951123466e4479842387a66fabfd6b65fc87fd84ae8e6cd3053edb27fff2fd", hashType: .data),
                     type: nil
                 )
             ],
             outputsData: [
                 "0x"
             ],
-            witnesses: [
-                "0x4107bd23eedb9f2a2a749108f6bb9720d745d50f044cc4814bafe189a01fe6fb",
-                "0x"
+            unsignedWitnesses: [
+                .parsed("0x4107bd23eedb9f2a2a749108f6bb9720d745d50f044cc4814bafe189a01fe6fb", "0x99caa8d7efdaab11c2bb7e45f4f385d0405f0fa2e8d3ba48496c28a2443e607d", "0xa6d5e23a77f4d7940aeb88764eebf8146185138641ac43b233e1c9b3daa170fa"),
+                .data("0x")
             ]
         )
         let privateKey = Data(hex: "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3")
         let signed = try Transaction.sign(tx: tx, with: privateKey)
         XCTAssertEqual(signed.witnesses.count, tx.inputs.count)
         XCTAssertEqual(
-            signed.witnesses.first,
-            "0x2db8278bf806fb7eac778e56eb0b34deccb16bae68c2a088d277bded265d90da37fb995a1f629a9de7c9722640f2f9c67c5572e6b5fca1e831649484ba9a0b81004107bd23eedb9f2a2a749108f6bb9720d745d50f044cc4814bafe189a01fe6fb"
+            signed.witnesses,
+            [
+                "0x9d00000010000000550000007900000041000000d896d67ddda97ab2d15cd13098b40e4a2b6d6c66ad465d987df9a28b0a038f4a18dbebbc702a1a0b2056aa9e4290a3640a4d73dd1f6483e6f8e0cd2784b4a78b002000000099caa8d7efdaab11c2bb7e45f4f385d0405f0fa2e8d3ba48496c28a2443e607d20000000a6d5e23a77f4d7940aeb88764eebf8146185138641ac43b233e1c9b3daa170fa",
+                "0x"
+            ]
         )
+    }
+
+    func testMultipleInputSign2() throws {
+       let tx = Transaction(
+             version: 0,
+             cellDeps: [
+                 CellDep(outPoint: OutPoint(txHash: "0xe7d5ddd093bcc5909a6f441882e58906062eaf66a6ac1bcf7d7411931bc9ab72", index: 0), depType: .depGroup)
+             ],
+             inputs: [
+                 CellInput(
+                     previousOutput: OutPoint(txHash: "0xa31b9b8d105c62d69b7fbfc09bd700f3a1d6659232ffcfaa12a048ee5d7b7f2d", index: 0),
+                     since: 0
+                 ),
+                 CellInput(
+                     previousOutput: OutPoint(txHash: "0xec5e63e19ec0161092ba78a841e9ead5deb30e56c2d98752ed974f2f2b4aeff2", index: 0),
+                     since: 0
+                 ),
+                 CellInput(
+                     previousOutput: OutPoint(txHash: "0x5ad2600cb884572f9d8f568822c0447f6f49eb63b53257c20d0d8559276bf4e2", index: 0),
+                     since: 0
+                 ),
+                 CellInput(
+                     previousOutput: OutPoint(txHash: "0xf21e34224e90c1ab47f42e2977ea455445d22ba3aaeb4bd2fcb2075704f330ff", index: 0),
+                     since: 0
+                 ),
+                 CellInput(
+                     previousOutput: OutPoint(txHash: "0xc8212696d516c63bced000d3008c4a8c27c72c03f4becb40f0bf24a31063271f", index: 0),
+                     since: 0
+                 )
+             ],
+             outputs: [
+                 CellOutput(
+                     capacity: 1000000000000,
+                     lock: Script(args: "0x59a27ef3ba84f061517d13f42cf44ed020610061", codeHash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8", hashType: .type),
+                     type: nil
+                 ),
+                 CellOutput(
+                     capacity: 19113828003,
+                     lock: Script(args: "0x3954acece65096bfa81258983ddb83915fc56bd8", codeHash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8", hashType: .type),
+                     type: nil
+                 )
+             ],
+             outputsData: [
+                 "0x",
+                 "0x"
+             ],
+             unsignedWitnesses: [
+                WitnessArgs.parsed("0x", "0x", "0x"),
+                WitnessArgs.data("0x"),
+                WitnessArgs.data("0x"),
+                WitnessArgs.data("0x"),
+                WitnessArgs.data("0x")
+             ]
+         )
+        let privateKey = Data(hex: "0x845b781a1a094057b972714a2b09b85de4fc2eb205351c3e5179aabd264f3805")
+        XCTAssertEqual("0x03aea57404a99c685b098b7ee96469f0c5db57fa49aaef27cf7c080960da4b19", tx.computeHash())
+        let signed = try Transaction.sign(tx: tx, with: privateKey)
         XCTAssertEqual(
-            signed.witnesses[1],
-            "0x014de9c721a5a33435a02d44580978ecdb794d2a7f3fe7d875e7f058ef8c961f2e983079400cfd8a2bbe34f2d1fd3f0a6e2c390bf7e45006c06c7831e4a67e8101"
+            "0x550000001000000055000000550000004100000090cdaca0b898586ef68c02e8514087e620d3b19767137baf2fbc8dee28c83ac047be76c76d7f5098a759f3d417c1daedf534a3772aa29159d807d948ed1f8c3a00",
+            signed.witnesses.first
         )
     }
 

--- a/Tests/Signers/WitnessArgsTests.swift
+++ b/Tests/Signers/WitnessArgsTests.swift
@@ -1,0 +1,24 @@
+//
+//  WitnessArgsSerializerTests.swift
+//
+//  Copyright © 2019 Nervos Foundation. All rights reserved.
+//
+
+import XCTest
+@testable import CKB
+
+class WitnessArgsTests: XCTestCase {
+    func testOptionValueSerialization() {
+        XCTAssertEqual(
+            [16, 0, 0, 0, 16, 0, 0, 0, 16, 0, 0, 0, 16, 0, 0, 0],
+            WitnessArgs.parsed("0x", "0x", "0x").serialize()
+        )
+    }
+
+    func testEmptyLock() {
+        XCTAssertEqual(
+            [85, 0, 0, 0, 16, 0, 0, 0, 85, 0, 0, 0, 85, 0, 0, 0, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            WitnessArgs.emptyLock.serialize()
+        )
+    }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
       sdk: 'macosx10.14'
       configuration: 'Debug'
       skip_rpc_tests: 0
-      ckb_version: 'v0.24.0-rc2'
+      ckb_version: 'v0.24.0'
     steps:
       - task: CocoaPods@0
         displayName: 'pod install using the CocoaPods task with defaults'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
       sdk: 'macosx10.14'
       configuration: 'Debug'
       skip_rpc_tests: 0
-      ckb_version: 'v0.23.0'
+      ckb_version: 'v0.24.0-rc1'
     steps:
       - task: CocoaPods@0
         displayName: 'pod install using the CocoaPods task with defaults'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
       sdk: 'macosx10.14'
       configuration: 'Debug'
       skip_rpc_tests: 0
-      ckb_version: 'v0.24.0-rc1'
+      ckb_version: 'v0.24.0-rc2'
     steps:
       - task: CocoaPods@0
         displayName: 'pod install using the CocoaPods task with defaults'


### PR DESCRIPTION
# [v0.24.0](https://github.com/nervosnetwork/ckb-sdk-swift/compare/v0.23.1...v0.24.0) (2019-11-02)


### Features

* Calculate transaction fee ([73dae6e](https://github.com/nervosnetwork/ckb-sdk-swift/commit/73dae6e))
* Implement estimate_fee_rate RPC ([9e43807](https://github.com/nervosnetwork/ckb-sdk-swift/commit/9e43807))
* Implement tx size calculation ([b4bac55](https://github.com/nervosnetwork/ckb-sdk-swift/commit/b4bac55))
* Implement WitnessArgs and its serializer ([f052a04](https://github.com/nervosnetwork/ckb-sdk-swift/commit/f052a04))
* Let WitnessArgs support both parsed witness and raw data ([15dfe74](https://github.com/nervosnetwork/ckb-sdk-swift/commit/15dfe74))
* Update tx signing ([499978e](https://github.com/nervosnetwork/ckb-sdk-swift/commit/499978e))

