### PR TITLE
[ᚬmaster] Rc/v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [v0.25.0](https://github.com/nervosnetwork/ckb-sdk-swift/compare/v0.24.0...v0.25.0) (2019-11-16)
+
+
+### Features
+
+* Limit address generator to support short payload format version ([0e5d410](https://github.com/nervosnetwork/ckb-sdk-swift/commit/0e5d410))
+
+
+
 # [v0.24.0](https://github.com/nervosnetwork/ckb-sdk-swift/compare/v0.23.1...v0.24.0) (2019-11-02)
 
 

--- a/CKB.podspec
+++ b/CKB.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CKB"
-  s.version      = "0.24.0"
+  s.version      = "0.25.0"
   s.summary      = "Swift SDK for Nervos CKB"
 
   s.description  = <<-DESC

--- a/CKB.xcodeproj/project.pbxproj
+++ b/CKB.xcodeproj/project.pbxproj
@@ -1156,7 +1156,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.24.0;
+				MARKETING_VERSION = 0.25.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nervos.CKB;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
@@ -1187,7 +1187,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.24.0;
+				MARKETING_VERSION = 0.25.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nervos.CKB;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;

--- a/Examples/Example-iOS/Podfile.lock
+++ b/Examples/Example-iOS/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CKB (0.23.0):
+  - CKB (0.24.0):
     - CryptoSwift (~> 1.0.0)
     - secp256k1.swift (~> 0.1.4)
     - Sodium (~> 0.8.0)
@@ -21,11 +21,11 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  CKB: 5f88ec50389d47d20e7bcdf4f18375a66e0130d6
+  CKB: 13d892b1e0d5d66140cfcb7fd931beea5d4693d3
   CryptoSwift: d81eeaa59dc5a8d03720fe919a6fd07b51f7439f
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   Sodium: 63c0ca312a932e6da481689537d4b35568841bdc
 
 PODFILE CHECKSUM: 25595363a3344f0facecf26229cae03aed8a81d9
 
-COCOAPODS: 1.8.3
+COCOAPODS: 1.8.4

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ target "MyApp" do
   use_frameworks!
   use_modular_headers!
 
-  pod "CKB", git: "https://github.com/nervosnetwork/ckb-sdk-swift.git", tag: "v0.19.0"
+  pod "CKB", git: "https://github.com/nervosnetwork/ckb-sdk-swift.git", tag: "v0.24.0"
 end
 ```
 
@@ -39,7 +39,7 @@ You can also use [Swift Package Manager](https://swift.org/package-manager/). In
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/nervosnetwork/ckb-sdk-swift", from: "0.19.0")
+  .package(url: "https://github.com/nervosnetwork/ckb-sdk-swift", from: "0.24.0")
 ]
 ```
 

--- a/Tests/Utils/AddressGeneratorTests.swift
+++ b/Tests/Utils/AddressGeneratorTests.swift
@@ -86,4 +86,10 @@ class AddressGeneratorTests: XCTestCase {
         XCTAssertFalse(AddressGenerator.validate("ckt1qyqrdaefa43s6m882pcj53m4gdnj4k440axqswmu83")) // None Bech32 character
         XCTAssertFalse(AddressGenerator.validate("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7")) // None ckt/ckb addresses
     }
+
+    func testValidateShortFormatSecpBlakeOnly() {
+        XCTAssertFalse(AddressGenerator.validate("ckb1qyqlqn8vsj7r0a5rvya76tey9jd2rdnca8lq2sg8su")) // Short format, multsig
+        XCTAssertFalse(AddressGenerator.validate("ckb1qsvf96jqmq4483ncl7yrzfzshwchu9jd0glq4yy5r2jcsw04d7xlydkr98kkxrtvuag8z2j8w4pkw2k6k4l5czfy37k")) // Full format: Type
+        XCTAssertFalse(AddressGenerator.validate("ckt1q2n9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5czshhac")) // Full format: Data
+    }
 }


### PR DESCRIPTION
# [v0.25.0](https://github.com/nervosnetwork/ckb-sdk-swift/compare/v0.24.0...v0.25.0) (2019-11-16)


### Features

* Limit address generator to support short payload format version ([0e5d410](https://github.com/nervosnetwork/ckb-sdk-swift/commit/0e5d410))

